### PR TITLE
fix: 프로젝트 필터링을 쿼리 레벨로 이동 및 캐시 API 개선

### DIFF
--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/postgres/repository/ProjectJpaRepository.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/postgres/repository/ProjectJpaRepository.java
@@ -4,7 +4,10 @@ package com.aiportfolio.backend.infrastructure.persistence.postgres.repository;
 import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.ProjectJpaEntity;
 
 // 외부 라이브러리 imports
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -18,7 +21,7 @@ import java.util.Optional;
  * Spring Data JPA를 사용한 데이터 액세스 레이어
  */
 @Repository
-public interface ProjectJpaRepository extends JpaRepository<ProjectJpaEntity, Long> {
+public interface ProjectJpaRepository extends JpaRepository<ProjectJpaEntity, Long>, JpaSpecificationExecutor<ProjectJpaEntity> {
     
     /**
      * 비즈니스 ID로 프로젝트 조회
@@ -83,6 +86,14 @@ public interface ProjectJpaRepository extends JpaRepository<ProjectJpaEntity, Lo
      */
     @Query("SELECT p FROM ProjectJpaEntity p ORDER BY p.sortOrder ASC, p.startDate DESC")
     List<ProjectJpaEntity> findAllOrderedBySortOrderAndStartDate();
+
+    /**
+     * 페이지네이션을 지원하는 모든 프로젝트 조회 (Admin용)
+     * @param pageable 페이지 정보
+     * @return 페이지네이션된 프로젝트 엔티티 리스트
+     */
+    @Query("SELECT p FROM ProjectJpaEntity p ORDER BY p.sortOrder ASC, p.startDate DESC")
+    Page<ProjectJpaEntity> findAllWithPagination(Pageable pageable);
     
     /**
      * GitHub URL이 있는 프로젝트만 조회

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/postgres/specification/ProjectSpecification.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/postgres/specification/ProjectSpecification.java
@@ -1,0 +1,93 @@
+package com.aiportfolio.backend.infrastructure.persistence.postgres.specification;
+
+import com.aiportfolio.backend.domain.admin.model.vo.ProjectFilter;
+import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.ProjectJpaEntity;
+import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.ProjectTechStackJpaEntity;
+import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.TechStackMetadataJpaEntity;
+import jakarta.persistence.criteria.*;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 프로젝트 필터링을 위한 JPA Specification
+ * 동적 쿼리 생성에 사용됩니다.
+ */
+public class ProjectSpecification {
+
+    /**
+     * ProjectFilter에 따라 Specification을 생성합니다.
+     * 
+     * @param filter 필터 조건
+     * @return Specification 객체
+     */
+    public static Specification<ProjectJpaEntity> withFilter(ProjectFilter filter) {
+        return (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            // 검색 쿼리 필터 (제목 또는 설명에 포함)
+            if (filter.hasSearchQuery()) {
+                String searchPattern = "%" + filter.getSearchQuery().toLowerCase() + "%";
+                Predicate titlePredicate = criteriaBuilder.like(
+                    criteriaBuilder.lower(root.get("title")), 
+                    searchPattern
+                );
+                Predicate descriptionPredicate = criteriaBuilder.like(
+                    criteriaBuilder.lower(root.get("description")), 
+                    searchPattern
+                );
+                predicates.add(criteriaBuilder.or(titlePredicate, descriptionPredicate));
+            }
+
+            // 팀 프로젝트 필터
+            if (filter.isTeamFilter()) {
+                predicates.add(criteriaBuilder.isTrue(root.get("isTeam")));
+            } else if (filter.isIndividualFilter()) {
+                predicates.add(criteriaBuilder.isFalse(root.get("isTeam")));
+            }
+
+            // 프로젝트 타입 필터
+            if (!filter.isAllType()) {
+                predicates.add(criteriaBuilder.equal(root.get("type"), filter.getProjectType()));
+            }
+
+            // 상태 필터
+            if (!filter.isAllStatus()) {
+                predicates.add(
+                    criteriaBuilder.equal(
+                        criteriaBuilder.lower(root.get("status")), 
+                        filter.getStatus().toLowerCase()
+                    )
+                );
+            }
+
+            // 기술 스택 필터 (JOIN 필요)
+            if (filter.hasTechFilter()) {
+                Join<ProjectJpaEntity, ProjectTechStackJpaEntity> techStackJoin = 
+                    root.join("projectTechStacks", JoinType.INNER);
+                Join<ProjectTechStackJpaEntity, TechStackMetadataJpaEntity> techMetadataJoin = 
+                    techStackJoin.join("techStack", JoinType.INNER);
+                
+                // 대소문자 구분 없이 비교 (selectedTechs의 각 항목을 소문자로 변환하여 비교)
+                List<Predicate> techStackPredicates = new ArrayList<>();
+                for (String techName : filter.getSelectedTechs()) {
+                    techStackPredicates.add(
+                        criteriaBuilder.equal(
+                            criteriaBuilder.lower(techMetadataJoin.get("name")),
+                            techName.toLowerCase()
+                        )
+                    );
+                }
+                // OR 조건: 선택된 기술 스택 중 하나라도 일치하면 됨
+                predicates.add(criteriaBuilder.or(techStackPredicates.toArray(new Predicate[0])));
+                
+                // 중복 제거를 위한 distinct
+                query.distinct(true);
+            }
+
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}
+

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/admin/controller/AdminCacheController.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/admin/controller/AdminCacheController.java
@@ -100,48 +100,12 @@ public class AdminCacheController {
     }
 
     /**
-     * 모든 캐시 키 목록 조회
+     * 캐시 키 목록 조회 (패턴 지원)
+     * pattern 파라미터가 없으면 모든 키를 조회합니다.
      */
     @GetMapping("/keys")
-    public ResponseEntity<Map<String, Object>> getAllCacheKeys(HttpServletRequest request) {
-        try {
-            adminAuthChecker.requireAuthentication(request);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(401).body(Map.of(
-                "success", false,
-                "message", e.getMessage(),
-                "timestamp", System.currentTimeMillis()
-            ));
-        }
-        log.info("Admin cache keys requested");
-
-        try {
-            List<String> keys = manageCacheUseCase.getAllCacheKeys();
-            log.info("Cache keys retrieved successfully: {} keys", keys.size());
-
-            return ResponseEntity.ok(Map.of(
-                "success", true,
-                "data", keys,
-                "count", keys.size(),
-                "timestamp", System.currentTimeMillis()
-            ));
-        } catch (Exception e) {
-            log.error("Cache keys retrieval failed", e);
-
-            return ResponseEntity.internalServerError().body(Map.of(
-                "success", false,
-                "message", "캐시 키 목록 조회 중 오류가 발생했습니다: " + e.getMessage(),
-                "timestamp", System.currentTimeMillis()
-            ));
-        }
-    }
-
-    /**
-     * 패턴별 캐시 키 목록 조회
-     */
-    @GetMapping("/keys/{pattern}")
-    public ResponseEntity<Map<String, Object>> getCacheKeysByPattern(
-            @PathVariable String pattern,
+    public ResponseEntity<Map<String, Object>> getCacheKeys(
+            @RequestParam(required = false, defaultValue = "*") String pattern,
             HttpServletRequest request) {
         try {
             adminAuthChecker.requireAuthentication(request);
@@ -179,9 +143,9 @@ public class AdminCacheController {
     /**
      * 패턴별 캐시 삭제
      */
-    @DeleteMapping("/pattern/{pattern}")
+    @DeleteMapping("/pattern")
     public ResponseEntity<Map<String, Object>> clearCacheByPattern(
-            @PathVariable String pattern,
+            @RequestParam String pattern,
             HttpServletRequest request) {
         try {
             adminAuthChecker.requireAuthentication(request);
@@ -193,11 +157,11 @@ public class AdminCacheController {
             ));
         }
         log.info("Admin cache clear by pattern requested: {}", pattern);
-        
+
         try {
             manageCacheUseCase.evictCacheByPattern(pattern);
             log.info("Cache cleared by pattern successfully: {}", pattern);
-            
+
             return ResponseEntity.ok(Map.of(
                 "success", true,
                 "message", "패턴별 캐시가 성공적으로 삭제되었습니다.",
@@ -206,7 +170,7 @@ public class AdminCacheController {
             ));
         } catch (Exception e) {
             log.error("Cache clear by pattern failed: {}", pattern, e);
-            
+
             return ResponseEntity.internalServerError().body(Map.of(
                 "success", false,
                 "message", "패턴별 캐시 삭제 중 오류가 발생했습니다: " + e.getMessage(),

--- a/frontend/src/admin/entities/cache/api/cacheApi.ts
+++ b/frontend/src/admin/entities/cache/api/cacheApi.ts
@@ -61,7 +61,7 @@ export const getAllCacheKeys = async (): Promise<string[]> => {
  * 패턴별 캐시 키 목록 조회
  */
 export const getCacheKeysByPattern = async (pattern: string): Promise<string[]> => {
-  const response = await fetch(`${API_BASE_URL}/keys/${encodeURIComponent(pattern)}`, {
+  const response = await fetch(`${API_BASE_URL}/keys?pattern=${encodeURIComponent(pattern)}`, {
     credentials: 'include', // 쿠키 포함 (세션 인증을 위해 필요)
   });
   if (!response.ok) {
@@ -95,7 +95,7 @@ export const clearAllCache = async (): Promise<void> => {
  * 패턴별 캐시 삭제
  */
 export const clearCacheByPattern = async (pattern: string): Promise<void> => {
-  const response = await fetch(`${API_BASE_URL}/pattern/${encodeURIComponent(pattern)}`, {
+  const response = await fetch(`${API_BASE_URL}/pattern?pattern=${encodeURIComponent(pattern)}`, {
     method: 'DELETE',
     credentials: 'include', // 쿠키 포함 (세션 인증을 위해 필요)
   });

--- a/frontend/src/admin/entities/cache/api/useCacheQuery.ts
+++ b/frontend/src/admin/entities/cache/api/useCacheQuery.ts
@@ -6,7 +6,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { message } from 'antd';
 import * as cacheApi from './cacheApi';
-import { queryClient as mainQueryClient } from '../../../main/config/queryClient';
+import { queryClient as mainQueryClient } from '../../../../main/config/queryClient';
 
 /**
  * 캐시 통계 조회 훅

--- a/frontend/src/admin/hooks/useProjects.ts
+++ b/frontend/src/admin/hooks/useProjects.ts
@@ -7,6 +7,8 @@ export const useProjects = (filter: ProjectFilter = {}) => {
     queryKey: ['admin-projects', filter],
     queryFn: () => adminProjectApi.getProjects(filter),
     select: (response) => response.data,
+    staleTime: 5 * 60 * 1000, // 5분간 캐시 유지 (성능 개선)
+    gcTime: 10 * 60 * 1000, // 10분 후 가비지 컬렉션
   });
 };
 

--- a/frontend/src/main/entities/project/api/useProjectsQuery.ts
+++ b/frontend/src/main/entities/project/api/useProjectsQuery.ts
@@ -33,7 +33,8 @@ export const useProjectsQuery = (params?: {
   return useQuery({
     queryKey: [...PROJECT_QUERY_KEYS.lists(), params],
     queryFn: () => projectApi.getProjects(params),
-    staleTime: 24 * 60 * 60 * 1000, // 24시간 - 콜드스타트 보완을 위해 긴 캐시 유지
+    staleTime: 3 * 60 * 1000, // 3분 - 관리자 수정 후 빠른 갱신 (트래픽 적음)
+    gcTime: 10 * 60 * 1000, // 10분 - 가비지 컬렉션 시간
   });
 };
 


### PR DESCRIPTION
주요 변경사항:
- 프로젝트 필터링 회귀 수정: 페이징 전 필터링 적용
  * Spring Data JPA Specification 도입
  * ProjectSpecification으로 동적 쿼리 생성
  * 검색, 타입, 상태, 팀, 기술스택 필터를 DB 쿼리로 처리
  * 정렬도 쿼리 레벨로 이동

- 캐시 관리 API 개선
  * 캐시 키 조회 API에 패턴 지원 추가
  * 프론트엔드 캐시 쿼리 훅 개선

백엔드:
- PostgresPortfolioRepository: findByFilter에서 Specification 사용
- ProjectJpaRepository: JpaSpecificationExecutor 추가
- ProjectSpecification: 새로 추가 (동적 필터링)
- AdminCacheController: 캐시 키 조회 API 리팩토링

프론트엔드:
- cacheApi, useCacheQuery: 캐시 관련 API 개선
- useProjects, useProjectsQuery: 프로젝트 쿼리 훅 업데이트