### PR TITLE
Simplify admin education mutation flow

### DIFF
--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/dto/education/EducationCommandRequest.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/dto/education/EducationCommandRequest.java
@@ -1,0 +1,63 @@
+package com.aiportfolio.backend.infrastructure.web.dto.education;
+
+import com.aiportfolio.backend.infrastructure.web.dto.relationship.BulkProjectRelationshipRequest;
+import com.aiportfolio.backend.infrastructure.web.dto.relationship.BulkTechStackRelationshipRequest;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 학력 기본 정보와 관계 정보를 함께 전달하기 위한 커맨드 요청 DTO.
+ *
+ * <p>관리자용 생성/수정 요청에서 사용되며, 하나의 트랜잭션 안에서
+ * 학력 기본 정보와 연관 관계(기술 스택, 프로젝트)를 모두 갱신합니다.</p>
+ */
+@Data
+public class EducationCommandRequest {
+
+    @NotBlank(message = "제목은 필수입니다")
+    private String title;
+
+    @Size(max = 2000, message = "설명은 2000자를 넘을 수 없습니다")
+    private String description;
+
+    @NotBlank(message = "교육기관은 필수입니다")
+    private String organization;
+
+    private String degree;
+
+    private String major;
+
+    @NotNull(message = "시작일은 필수입니다")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    private BigDecimal gpa;
+
+    @NotBlank(message = "타입은 필수입니다")
+    private String type;
+
+    private Integer sortOrder;
+
+    private List<BulkTechStackRelationshipRequest.TechStackRelationshipItem> techStackRelationships;
+
+    private List<BulkProjectRelationshipRequest.ProjectRelationshipItem> projectRelationships;
+
+    public List<BulkTechStackRelationshipRequest.TechStackRelationshipItem> safeTechStackRelationships() {
+        return techStackRelationships != null ? techStackRelationships : Collections.emptyList();
+    }
+
+    public List<BulkProjectRelationshipRequest.ProjectRelationshipItem> safeProjectRelationships() {
+        return projectRelationships != null ? projectRelationships : Collections.emptyList();
+    }
+}

--- a/frontend/src/admin/entities/education/model/education.types.ts
+++ b/frontend/src/admin/entities/education/model/education.types.ts
@@ -35,9 +35,23 @@ export interface EducationFormData {
   endDate?: string;
   gpa?: number;
   type: EducationType;
-  technologies: string[];
-  projects: string[];
+  technologies?: string[];
+  projects?: string[];
   sortOrder?: number;
+  techStackRelationships: Array<{
+    techStackId: number;
+    isPrimary?: boolean;
+    usageDescription?: string;
+  }>;
+  projectRelationships: Array<{
+    projectBusinessId: string;
+    projectType?: string;
+    grade?: string;
+    isPrimary?: boolean;
+    usageDescription?: string;
+    roleInProject?: string;
+    contributionDescription?: string;
+  }>;
 }
 
 // Education 필터

--- a/frontend/src/admin/entities/project/model/project.types.ts
+++ b/frontend/src/admin/entities/project/model/project.types.ts
@@ -49,5 +49,7 @@ export interface EntityProjectRelationship {
   usageDescription?: string;
   roleInProject?: string; // Experience-Project용
   contributionDescription?: string; // Experience-Project용
+  projectType?: string; // Education-Project용
+  grade?: string; // Education-Project용
 }
 

--- a/frontend/src/admin/shared/ui/ProjectRelationshipSection.tsx
+++ b/frontend/src/admin/shared/ui/ProjectRelationshipSection.tsx
@@ -15,6 +15,7 @@ const { TextArea } = Input;
 interface ProjectRelationshipSectionProps {
   value: EntityProjectRelationship[];
   onChange: (relationships: EntityProjectRelationship[]) => void;
+  mode?: 'education' | 'experience';
 }
 
 /**
@@ -24,17 +25,17 @@ interface ProjectRelationshipSectionProps {
 export const ProjectRelationshipSection: React.FC<ProjectRelationshipSectionProps> = ({
   value = [],
   onChange,
+  mode = 'experience',
 }) => {
   const { message } = App.useApp();
   const [selectingProject, setSelectingProject] = useState<string | null>(null);
   const [isPrimary, setIsPrimary] = useState(false);
   const [usageDescription, setUsageDescription] = useState('');
+  const [projectType, setProjectType] = useState('');
+  const [grade, setGrade] = useState('');
   
   // 캐시된 프로젝트 목록 조회 (관리자 API 사용)
   const { data: allProjects, isLoading } = useProjects({});
-
-  // 이미 선택된 프로젝트 Business ID 목록
-  const selectedIds = useMemo(() => value.map((v) => v.projectBusinessId), [value]);
 
   // 추가 가능한 프로젝트만 필터링
   // 기존 프로젝트는 제외하지 않고 모든 프로젝트 표시
@@ -58,6 +59,8 @@ export const ProjectRelationshipSection: React.FC<ProjectRelationshipSectionProp
       projectTitle: selectedProject.title,
       isPrimary,
       usageDescription: usageDescription.trim() || undefined,
+      projectType: mode === 'education' ? projectType.trim() || undefined : undefined,
+      grade: mode === 'education' ? grade.trim() || undefined : undefined,
     };
 
     onChange([...value, newRelationship]);
@@ -65,6 +68,8 @@ export const ProjectRelationshipSection: React.FC<ProjectRelationshipSectionProp
     setSelectingProject(null);
     setIsPrimary(false);
     setUsageDescription('');
+    setProjectType('');
+    setGrade('');
     message.success(`${selectedProject.title}이(가) 추가되었습니다`);
   };
 
@@ -110,6 +115,20 @@ export const ProjectRelationshipSection: React.FC<ProjectRelationshipSectionProp
               />{' '}
               <span style={{ marginLeft: '8px', fontSize: '14px' }}>주요 프로젝트</span>
             </div>
+            {mode === 'education' && (
+              <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
+                <Input
+                  placeholder="프로젝트 유형"
+                  value={projectType}
+                  onChange={(e) => setProjectType(e.target.value)}
+                />
+                <Input
+                  placeholder="성적/성과"
+                  value={grade}
+                  onChange={(e) => setGrade(e.target.value)}
+                />
+              </div>
+            )}
             <TextArea
               placeholder="사용 내용 설명 (선택사항)"
               value={usageDescription}
@@ -155,6 +174,12 @@ export const ProjectRelationshipSection: React.FC<ProjectRelationshipSectionProp
                       </Tag>
                     )}
                   </div>
+                  {mode === 'education' && (item.projectType || item.grade) && (
+                    <div style={{ fontSize: '12px', color: '#666', marginTop: '4px' }}>
+                      {item.projectType && <div>프로젝트 유형: {item.projectType}</div>}
+                      {item.grade && <div>성적/성과: {item.grade}</div>}
+                    </div>
+                  )}
                   {item.usageDescription && (
                     <div style={{ fontSize: '12px', color: '#666', marginTop: '4px' }}>
                       {item.usageDescription}


### PR DESCRIPTION
## Summary
- simplify `ManageEducationService` so create/update mutations receive the education domain object plus lightweight relation records
- update the admin education controller to build those inputs directly from the request and drop the aggregate helper
- remove the now-unused `EducationAggregateCommand` model class

## Testing
- npm run build *(fails: vite: not found in container)*
- (cd backend && mvn -q -DskipTests compile) *(fails: Maven Central returns HTTP 403 for spring-boot-starter-parent)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691526150f5c83339b97f62b2fa2cd7c)