### PR TITLE
feat: expose admin cloud usage dashboard API

### DIFF
--- a/backend/src/main/java/com/aiportfolio/backend/application/admin/service/CloudUsageQueryService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/admin/service/CloudUsageQueryService.java
@@ -1,0 +1,45 @@
+package com.aiportfolio.backend.application.admin.service;
+
+import com.aiportfolio.backend.domain.admin.dto.response.CloudUsageDashboardResponse;
+import com.aiportfolio.backend.domain.admin.model.dto.CloudUsageSnapshot;
+import com.aiportfolio.backend.domain.admin.port.in.GetCloudUsageUseCase;
+import com.aiportfolio.backend.domain.admin.port.out.CloudUsageProviderPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 다수의 클라우드 사용량 제공자를 집계하여 관리자 대시보드 응답을 생성합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CloudUsageQueryService implements GetCloudUsageUseCase {
+
+    private final List<CloudUsageProviderPort> providerPorts;
+
+    @Override
+    public CloudUsageDashboardResponse getRealTimeUsage() {
+        List<CloudUsageSnapshot> snapshots = providerPorts.stream()
+            .map(port -> {
+                try {
+                    CloudUsageSnapshot snapshot = port.fetchCurrentUsage();
+                    return snapshot == null ? null : snapshot.withDefaults();
+                } catch (Exception exception) {
+                    log.error("Failed to fetch usage for provider {}", port.getProvider(), exception);
+                    return CloudUsageSnapshot.failure(port.getProvider(), exception.getMessage());
+                }
+            })
+            .filter(snapshot -> snapshot != null)
+            .collect(Collectors.toList());
+
+        return CloudUsageDashboardResponse.builder()
+            .generatedAt(Instant.now())
+            .snapshots(snapshots)
+            .build();
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/domain/admin/dto/response/CloudUsageDashboardResponse.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/admin/dto/response/CloudUsageDashboardResponse.java
@@ -1,0 +1,27 @@
+package com.aiportfolio.backend.domain.admin.dto.response;
+
+import com.aiportfolio.backend.domain.admin.model.dto.CloudUsageSnapshot;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 관리자 대시보드에서 사용하는 클라우드 사용량 요약 응답입니다.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CloudUsageDashboardResponse {
+
+    @Builder.Default
+    private Instant generatedAt = Instant.now();
+
+    @Builder.Default
+    private List<CloudUsageSnapshot> snapshots = Collections.emptyList();
+}

--- a/backend/src/main/java/com/aiportfolio/backend/domain/admin/model/dto/CloudUsageMetric.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/admin/model/dto/CloudUsageMetric.java
@@ -1,0 +1,20 @@
+package com.aiportfolio.backend.domain.admin.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 단일 클라우드 사용량 지표를 나타냅니다.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CloudUsageMetric {
+    private String name;
+    private Double value;
+    private String unit;
+    private String description;
+}

--- a/backend/src/main/java/com/aiportfolio/backend/domain/admin/model/dto/CloudUsageSnapshot.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/admin/model/dto/CloudUsageSnapshot.java
@@ -1,0 +1,104 @@
+package com.aiportfolio.backend.domain.admin.model.dto;
+
+import com.aiportfolio.backend.domain.admin.model.vo.CloudProvider;
+import com.aiportfolio.backend.domain.admin.model.vo.CloudUsageStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * 특정 시점의 클라우드 사용량 스냅샷입니다.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CloudUsageSnapshot {
+
+    private CloudProvider provider;
+    private CloudUsageStatus status;
+    private Instant collectedAt;
+    private String region;
+    private String message;
+
+    @Builder.Default
+    private List<CloudUsageMetric> metrics = Collections.emptyList();
+
+    @Builder.Default
+    private Map<String, Object> metadata = Collections.emptyMap();
+
+    public static CloudUsageSnapshot disabled(CloudProvider provider, String message) {
+        return CloudUsageSnapshot.builder()
+            .provider(provider)
+            .status(CloudUsageStatus.DISABLED)
+            .message(message)
+            .collectedAt(Instant.now())
+            .build();
+    }
+
+    public static CloudUsageSnapshot unavailable(CloudProvider provider, String message) {
+        return CloudUsageSnapshot.builder()
+            .provider(provider)
+            .status(CloudUsageStatus.UNAVAILABLE)
+            .message(message)
+            .collectedAt(Instant.now())
+            .build();
+    }
+
+    public static CloudUsageSnapshot failure(CloudProvider provider, String message) {
+        return unavailable(provider, message);
+    }
+
+    public void ensureDefaults() {
+        if (collectedAt == null) {
+            collectedAt = Instant.now();
+        }
+        if (status == null) {
+            status = CloudUsageStatus.UNAVAILABLE;
+        }
+        if (metrics == null) {
+            metrics = Collections.emptyList();
+        }
+        if (metadata == null) {
+            metadata = Collections.emptyMap();
+        }
+        if (message == null) {
+            message = "";
+        }
+    }
+
+    public CloudUsageSnapshot withDefaults() {
+        ensureDefaults();
+        return this;
+    }
+
+    public boolean isHealthy() {
+        return status == CloudUsageStatus.HEALTHY || status == CloudUsageStatus.DEGRADED;
+    }
+
+    public boolean hasMetrics() {
+        return metrics != null && !metrics.isEmpty();
+    }
+
+    public CloudUsageSnapshot addMetadata(Map<String, Object> additional) {
+        if (additional == null || additional.isEmpty()) {
+            return this;
+        }
+
+        if (metadata == null || metadata.isEmpty()) {
+            metadata = additional;
+            return this;
+        }
+
+        metadata = new java.util.HashMap<>(metadata);
+        additional.forEach((key, value) -> metadata.put(key, Objects.requireNonNullElse(value, "")));
+        return this;
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/domain/admin/model/vo/CloudProvider.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/admin/model/vo/CloudProvider.java
@@ -1,0 +1,9 @@
+package com.aiportfolio.backend.domain.admin.model.vo;
+
+/**
+ * 지원 중인 클라우드 공급자 종류를 정의합니다.
+ */
+public enum CloudProvider {
+    AWS,
+    GCP
+}

--- a/backend/src/main/java/com/aiportfolio/backend/domain/admin/model/vo/CloudUsageStatus.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/admin/model/vo/CloudUsageStatus.java
@@ -1,0 +1,32 @@
+package com.aiportfolio.backend.domain.admin.model.vo;
+
+import java.util.Locale;
+
+/**
+ * 클라우드 사용량 데이터의 상태를 나타냅니다.
+ */
+public enum CloudUsageStatus {
+    HEALTHY,
+    DEGRADED,
+    UNAVAILABLE,
+    DISABLED;
+
+    /**
+     * 외부 API의 상태 문자열을 안전하게 {@link CloudUsageStatus}로 변환합니다.
+     * 예상치 못한 값은 {@link #UNAVAILABLE}로 매핑됩니다.
+     *
+     * @param status 외부 API에서 전달된 상태 문자열
+     * @return 변환된 {@link CloudUsageStatus}
+     */
+    public static CloudUsageStatus from(String status) {
+        if (status == null) {
+            return UNAVAILABLE;
+        }
+
+        try {
+            return valueOf(status.trim().toUpperCase(Locale.ENGLISH));
+        } catch (IllegalArgumentException ignored) {
+            return UNAVAILABLE;
+        }
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/domain/admin/port/in/GetCloudUsageUseCase.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/admin/port/in/GetCloudUsageUseCase.java
@@ -1,0 +1,16 @@
+package com.aiportfolio.backend.domain.admin.port.in;
+
+import com.aiportfolio.backend.domain.admin.dto.response.CloudUsageDashboardResponse;
+
+/**
+ * 클라우드 사용량 정보를 조회하는 유스케이스입니다.
+ */
+public interface GetCloudUsageUseCase {
+
+    /**
+     * AWS, GCP 등 활성화된 모든 공급자의 실시간 사용량을 조회합니다.
+     *
+     * @return 대시보드 표시용 사용량 요약
+     */
+    CloudUsageDashboardResponse getRealTimeUsage();
+}

--- a/backend/src/main/java/com/aiportfolio/backend/domain/admin/port/out/CloudUsageProviderPort.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/admin/port/out/CloudUsageProviderPort.java
@@ -1,0 +1,24 @@
+package com.aiportfolio.backend.domain.admin.port.out;
+
+import com.aiportfolio.backend.domain.admin.model.dto.CloudUsageSnapshot;
+import com.aiportfolio.backend.domain.admin.model.vo.CloudProvider;
+
+/**
+ * 외부 클라우드 사용량 데이터를 가져오는 포트입니다.
+ */
+public interface CloudUsageProviderPort {
+
+    /**
+     * 포트가 담당하는 클라우드 공급자를 반환합니다.
+     *
+     * @return {@link CloudProvider}
+     */
+    CloudProvider getProvider();
+
+    /**
+     * 현재 시점의 사용량 정보를 조회합니다.
+     *
+     * @return 사용량 스냅샷
+     */
+    CloudUsageSnapshot fetchCurrentUsage();
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/CloudUsageProperties.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/CloudUsageProperties.java
@@ -1,0 +1,47 @@
+package com.aiportfolio.backend.infrastructure.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 클라우드 사용량 조회에 필요한 외부 API 구성 정보를 보관합니다.
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "cloud.usage")
+public class CloudUsageProperties {
+
+    /**
+     * 외부 API 요청 타임아웃 기본값.
+     */
+    private Duration timeout = Duration.ofSeconds(10);
+
+    /**
+     * 공급자별 설정 값.
+     */
+    private Map<String, ProviderProperties> providers = new HashMap<>();
+
+    public ProviderProperties getAws() {
+        return providers.computeIfAbsent("aws", key -> new ProviderProperties());
+    }
+
+    public ProviderProperties getGcp() {
+        return providers.computeIfAbsent("gcp", key -> new ProviderProperties());
+    }
+
+    @Data
+    public static class ProviderProperties {
+        private boolean enabled = false;
+        private String endpoint;
+        private String apiKey;
+        private String region;
+        private String projectId;
+        private Map<String, String> headers = new HashMap<>();
+        private Map<String, String> query = new HashMap<>();
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/external/cloud/adapter/AbstractCloudUsageAdapter.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/external/cloud/adapter/AbstractCloudUsageAdapter.java
@@ -1,0 +1,117 @@
+package com.aiportfolio.backend.infrastructure.external.cloud.adapter;
+
+import com.aiportfolio.backend.domain.admin.model.dto.CloudUsageSnapshot;
+import com.aiportfolio.backend.domain.admin.model.vo.CloudProvider;
+import com.aiportfolio.backend.domain.admin.model.vo.CloudUsageStatus;
+import com.aiportfolio.backend.domain.admin.port.out.CloudUsageProviderPort;
+import com.aiportfolio.backend.infrastructure.config.CloudUsageProperties;
+import com.aiportfolio.backend.infrastructure.external.cloud.dto.CloudUsageApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 공통 HTTP 기반 클라우드 사용량 어댑터 구현입니다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractCloudUsageAdapter implements CloudUsageProviderPort {
+
+    private final RestTemplate restTemplate;
+    private final CloudUsageProperties properties;
+
+    @Override
+    public CloudUsageSnapshot fetchCurrentUsage() {
+        CloudUsageProperties.ProviderProperties config = getProviderProperties();
+
+        if (config == null || !config.isEnabled()) {
+            return CloudUsageSnapshot.disabled(getProvider(), getProvider().name() + " usage integration disabled");
+        }
+
+        if (!StringUtils.hasText(config.getEndpoint())) {
+            return CloudUsageSnapshot.unavailable(getProvider(), "Usage endpoint is not configured");
+        }
+
+        try {
+            URI requestUri = buildUri(config);
+            HttpEntity<Void> requestEntity = new HttpEntity<>(buildHeaders(config));
+            ResponseEntity<CloudUsageApiResponse> response = restTemplate.exchange(
+                requestUri,
+                HttpMethod.GET,
+                requestEntity,
+                CloudUsageApiResponse.class
+            );
+
+            CloudUsageApiResponse body = response.getBody();
+            if (body == null) {
+                throw new IllegalStateException("Empty response from " + getProvider().name() + " usage API");
+            }
+
+            CloudUsageSnapshot snapshot = CloudUsageSnapshot.builder()
+                .provider(getProvider())
+                .status(Optional.ofNullable(body.getStatus()).map(CloudUsageStatus::from).orElse(CloudUsageStatus.UNAVAILABLE))
+                .region(Optional.ofNullable(body.getRegion()).filter(StringUtils::hasText).orElse(config.getRegion()))
+                .collectedAt(Optional.ofNullable(body.getCollectedAt()).orElse(Instant.now()))
+                .message(body.getMessage())
+                .metrics(body.toMetrics())
+                .metadata(body.getMetadata())
+                .build();
+
+            return snapshot.withDefaults();
+        } catch (Exception exception) {
+            log.error("Failed to fetch usage metrics for provider {}", getProvider(), exception);
+            return CloudUsageSnapshot.failure(getProvider(), exception.getMessage());
+        }
+    }
+
+    @Override
+    public abstract CloudProvider getProvider();
+
+    protected abstract CloudUsageProperties.ProviderProperties getProviderProperties();
+
+    protected CloudUsageProperties getProperties() {
+        return properties;
+    }
+
+    private URI buildUri(CloudUsageProperties.ProviderProperties config) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(config.getEndpoint());
+        Map<String, String> queryParams = config.getQuery();
+        if (queryParams != null) {
+            queryParams.forEach(builder::queryParam);
+        }
+        return builder.build().toUri();
+    }
+
+    private HttpHeaders buildHeaders(CloudUsageProperties.ProviderProperties config) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+
+        if (StringUtils.hasText(config.getApiKey())) {
+            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + config.getApiKey());
+        }
+
+        Map<String, String> additionalHeaders = config.getHeaders();
+        if (additionalHeaders != null) {
+            additionalHeaders.forEach((key, value) -> {
+                if (StringUtils.hasText(key) && StringUtils.hasText(value)) {
+                    headers.set(key, value);
+                }
+            });
+        }
+
+        return headers;
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/external/cloud/adapter/AwsCloudUsageAdapter.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/external/cloud/adapter/AwsCloudUsageAdapter.java
@@ -1,0 +1,27 @@
+package com.aiportfolio.backend.infrastructure.external.cloud.adapter;
+
+import com.aiportfolio.backend.domain.admin.model.vo.CloudProvider;
+import com.aiportfolio.backend.infrastructure.config.CloudUsageProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * AWS 사용량 조회 어댑터.
+ */
+@Component
+public class AwsCloudUsageAdapter extends AbstractCloudUsageAdapter {
+
+    public AwsCloudUsageAdapter(RestTemplate restTemplate, CloudUsageProperties properties) {
+        super(restTemplate, properties);
+    }
+
+    @Override
+    public CloudProvider getProvider() {
+        return CloudProvider.AWS;
+    }
+
+    @Override
+    protected CloudUsageProperties.ProviderProperties getProviderProperties() {
+        return getProperties().getAws();
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/external/cloud/adapter/GcpCloudUsageAdapter.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/external/cloud/adapter/GcpCloudUsageAdapter.java
@@ -1,0 +1,27 @@
+package com.aiportfolio.backend.infrastructure.external.cloud.adapter;
+
+import com.aiportfolio.backend.domain.admin.model.vo.CloudProvider;
+import com.aiportfolio.backend.infrastructure.config.CloudUsageProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * GCP 사용량 조회 어댑터.
+ */
+@Component
+public class GcpCloudUsageAdapter extends AbstractCloudUsageAdapter {
+
+    public GcpCloudUsageAdapter(RestTemplate restTemplate, CloudUsageProperties properties) {
+        super(restTemplate, properties);
+    }
+
+    @Override
+    public CloudProvider getProvider() {
+        return CloudProvider.GCP;
+    }
+
+    @Override
+    protected CloudUsageProperties.ProviderProperties getProviderProperties() {
+        return getProperties().getGcp();
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/external/cloud/dto/CloudUsageApiResponse.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/external/cloud/dto/CloudUsageApiResponse.java
@@ -1,0 +1,56 @@
+package com.aiportfolio.backend.infrastructure.external.cloud.dto;
+
+import com.aiportfolio.backend.domain.admin.model.dto.CloudUsageMetric;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 외부 사용량 API 응답을 매핑하기 위한 DTO 입니다.
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CloudUsageApiResponse {
+
+    private String status;
+
+    private String message;
+
+    private String region;
+
+    @JsonProperty("collected_at")
+    private Instant collectedAt;
+
+    private List<MetricResponse> metrics = Collections.emptyList();
+
+    private Map<String, Object> metadata = Collections.emptyMap();
+
+    public List<CloudUsageMetric> toMetrics() {
+        if (metrics == null) {
+            return Collections.emptyList();
+        }
+        return metrics.stream()
+            .map(metric -> CloudUsageMetric.builder()
+                .name(metric.getName())
+                .unit(metric.getUnit())
+                .value(metric.getValue())
+                .description(metric.getDescription())
+                .build())
+            .collect(Collectors.toList());
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class MetricResponse {
+        private String name;
+        private Double value;
+        private String unit;
+        private String description;
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/admin/controller/AdminCloudUsageController.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/admin/controller/AdminCloudUsageController.java
@@ -1,0 +1,29 @@
+package com.aiportfolio.backend.infrastructure.web.admin.controller;
+
+import com.aiportfolio.backend.domain.admin.dto.response.CloudUsageDashboardResponse;
+import com.aiportfolio.backend.domain.admin.port.in.GetCloudUsageUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 대시보드용 클라우드 사용량 API.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/cloud/usage")
+public class AdminCloudUsageController {
+
+    private final GetCloudUsageUseCase getCloudUsageUseCase;
+
+    @GetMapping
+    public ResponseEntity<CloudUsageDashboardResponse> getUsage() {
+        log.debug("Fetching real-time cloud usage snapshot for admin dashboard");
+        CloudUsageDashboardResponse response = getCloudUsageUseCase.getRealTimeUsage();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -156,3 +156,17 @@ cloudinary:
   cloud-name: ${CLOUDINARY_CLOUD_NAME:}
   api-key: ${CLOUDINARY_API_KEY:}
   api-secret: ${CLOUDINARY_API_SECRET:}
+
+cloud:
+  usage:
+    providers:
+      aws:
+        enabled: false
+        endpoint:
+        region: ${AWS_USAGE_REGION:}
+        api-key: ${AWS_USAGE_API_KEY:}
+      gcp:
+        enabled: false
+        endpoint:
+        project-id: ${GCP_USAGE_PROJECT_ID:}
+        api-key: ${GCP_USAGE_API_KEY:}

--- a/backend/src/main/resources/application-production.yml
+++ b/backend/src/main/resources/application-production.yml
@@ -147,3 +147,17 @@ cloudinary:
   cloud-name: ${CLOUDINARY_CLOUD_NAME}
   api-key: ${CLOUDINARY_API_KEY}
   api-secret: ${CLOUDINARY_API_SECRET}
+
+cloud:
+  usage:
+    providers:
+      aws:
+        enabled: ${AWS_USAGE_ENABLED:false}
+        endpoint: ${AWS_USAGE_ENDPOINT:}
+        region: ${AWS_USAGE_REGION:}
+        api-key: ${AWS_USAGE_API_KEY:}
+      gcp:
+        enabled: ${GCP_USAGE_ENABLED:false}
+        endpoint: ${GCP_USAGE_ENDPOINT:}
+        project-id: ${GCP_USAGE_PROJECT_ID:}
+        api-key: ${GCP_USAGE_API_KEY:}

--- a/backend/src/main/resources/application-staging.yml
+++ b/backend/src/main/resources/application-staging.yml
@@ -159,3 +159,17 @@ cloudinary:
   cloud-name: ${CLOUDINARY_CLOUD_NAME}
   api-key: ${CLOUDINARY_API_KEY}
   api-secret: ${CLOUDINARY_API_SECRET}
+
+cloud:
+  usage:
+    providers:
+      aws:
+        enabled: ${AWS_USAGE_ENABLED:false}
+        endpoint: ${AWS_USAGE_ENDPOINT:}
+        region: ${AWS_USAGE_REGION:}
+        api-key: ${AWS_USAGE_API_KEY:}
+      gcp:
+        enabled: ${GCP_USAGE_ENABLED:false}
+        endpoint: ${GCP_USAGE_ENDPOINT:}
+        project-id: ${GCP_USAGE_PROJECT_ID:}
+        api-key: ${GCP_USAGE_API_KEY:}


### PR DESCRIPTION
## Summary
- add domain and application layers for aggregating cloud usage snapshots
- implement AWS and GCP HTTP adapters plus an admin API endpoint for real-time usage
- provide configuration scaffolding for provider endpoints across environments

## Testing
- mvn -f backend/pom.xml test *(fails: Maven cannot download Spring Boot parent due to HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916a00506e483339d727530d3361748)