### PR TITLE
Serialize `isTeam` in public project responses and use merge adapters for tech-stack relations

### DIFF
--- a/backend/src/main/java/com/aiportfolio/backend/domain/portfolio/model/Project.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/portfolio/model/Project.java
@@ -124,4 +124,3 @@ public class Project {
         return size;
     }
 }
-

--- a/backend/src/main/java/com/aiportfolio/backend/domain/portfolio/port/out/ExperienceRelationshipPort.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/portfolio/port/out/ExperienceRelationshipPort.java
@@ -1,0 +1,19 @@
+package com.aiportfolio.backend.domain.portfolio.port.out;
+
+import java.util.List;
+
+/**
+ * Experience와 TechStack 간의 관계를 관리하는 인터페이스
+ */
+public interface ExperienceRelationshipPort {
+
+    /**
+     * Experience-TechStack 관계를 교체 (머지 전략)
+     *
+     * @param experienceBusinessId Experience Business ID
+     * @param relationships TechStack 관계 리스트
+     */
+    void replaceTechStacks(String experienceBusinessId, List<TechStackRelation> relationships);
+
+    record TechStackRelation(Long techStackId, boolean isPrimary, String usageDescription) {}
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/postgres/adapter/ExperienceRelationshipAdapter.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/postgres/adapter/ExperienceRelationshipAdapter.java
@@ -1,0 +1,102 @@
+package com.aiportfolio.backend.infrastructure.persistence.postgres.adapter;
+
+import com.aiportfolio.backend.domain.portfolio.port.out.ExperienceRelationshipPort;
+import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.ExperienceJpaEntity;
+import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.ExperienceTechStackJpaEntity;
+import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.TechStackMetadataJpaEntity;
+import com.aiportfolio.backend.infrastructure.persistence.postgres.repository.ExperienceJpaRepository;
+import com.aiportfolio.backend.infrastructure.persistence.postgres.repository.ExperienceTechStackJpaRepository;
+import com.aiportfolio.backend.infrastructure.persistence.postgres.repository.TechStackMetadataJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Experience 관계 관리 Adapter
+ *
+ * Experience와 TechStack 간의 관계를 관리하는 구현체
+ *
+ * Merge 전략을 사용하여 불필요한 DELETE/INSERT를 최소화하고
+ * duplicate key constraint violation을 방지합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ExperienceRelationshipAdapter implements ExperienceRelationshipPort {
+
+    private final ExperienceJpaRepository experienceJpaRepository;
+    private final ExperienceTechStackJpaRepository experienceTechStackJpaRepository;
+    private final TechStackMetadataJpaRepository techStackMetadataJpaRepository;
+
+    @Override
+    public void replaceTechStacks(String experienceBusinessId, List<TechStackRelation> relationships) {
+        log.debug("Replacing tech stacks for experience: {} (using merge strategy)", experienceBusinessId);
+
+        ExperienceJpaEntity experience = experienceJpaRepository.findByBusinessId(experienceBusinessId)
+                .orElseThrow(() -> new IllegalArgumentException("Experience not found: " + experienceBusinessId));
+
+        List<ExperienceTechStackJpaEntity> existingRelations =
+                experienceTechStackJpaRepository.findByExperienceId(experience.getId());
+        log.debug("Found {} existing tech stack relationships", existingRelations.size());
+
+        Set<Long> requestedIds = (relationships == null || relationships.isEmpty())
+                ? Collections.emptySet()
+                : relationships.stream()
+                        .map(TechStackRelation::techStackId)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet());
+        log.debug("Requested tech stack IDs: {}", requestedIds);
+
+        List<ExperienceTechStackJpaEntity> toDelete = existingRelations.stream()
+                .filter(existing -> !requestedIds.contains(existing.getTechStack().getId()))
+                .collect(Collectors.toList());
+
+        if (!toDelete.isEmpty()) {
+            log.debug("Deleting {} tech stack relationships", toDelete.size());
+            experienceTechStackJpaRepository.deleteAll(toDelete);
+            experienceTechStackJpaRepository.flush();
+        }
+
+        Set<Long> existingIds = existingRelations.stream()
+                .map(existing -> existing.getTechStack().getId())
+                .collect(Collectors.toSet());
+
+        List<TechStackRelation> toAdd = (relationships == null || relationships.isEmpty())
+                ? Collections.emptyList()
+                : relationships.stream()
+                        .filter(rel -> !existingIds.contains(rel.techStackId()))
+                        .collect(Collectors.toList());
+
+        if (!toAdd.isEmpty()) {
+            log.debug("Adding {} new tech stack relationships", toAdd.size());
+            for (TechStackRelation item : toAdd) {
+                if (item.techStackId() == null) {
+                    throw new IllegalArgumentException("Tech stack ID must not be null");
+                }
+
+                TechStackMetadataJpaEntity techStack = techStackMetadataJpaRepository.findById(item.techStackId())
+                        .orElseThrow(() -> new IllegalArgumentException("TechStack not found: " + item.techStackId()));
+
+                ExperienceTechStackJpaEntity relation = ExperienceTechStackJpaEntity.builder()
+                        .experience(experience)
+                        .techStack(techStack)
+                        .isPrimary(item.isPrimary())
+                        .usageDescription(item.usageDescription())
+                        .build();
+
+                experienceTechStackJpaRepository.save(relation);
+            }
+        }
+
+        log.debug("Successfully replaced tech stacks for experience: {} (deleted: {}, added: {})",
+                experienceBusinessId, toDelete.size(), toAdd.size());
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/admin/controller/AdminEducationRelationshipController.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/admin/controller/AdminEducationRelationshipController.java
@@ -1,5 +1,6 @@
 package com.aiportfolio.backend.infrastructure.web.admin.controller;
 
+import com.aiportfolio.backend.domain.portfolio.port.out.EducationRelationshipPort;
 import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.*;
 import com.aiportfolio.backend.infrastructure.persistence.postgres.repository.*;
 import com.aiportfolio.backend.infrastructure.web.dto.ApiResponse;
@@ -31,6 +32,7 @@ public class AdminEducationRelationshipController {
     private final ProjectJpaRepository projectJpaRepository;
     private final EducationTechStackJpaRepository educationTechStackJpaRepository;
     private final EducationProjectJpaRepository educationProjectJpaRepository;
+    private final EducationRelationshipPort educationRelationshipPort;
 
     // ==================== 기술스택 관계 ====================
 
@@ -141,37 +143,18 @@ public class AdminEducationRelationshipController {
             @PathVariable String id,
             @RequestBody BulkTechStackRelationshipRequest request) {
         try {
-            EducationJpaEntity education = educationJpaRepository.findByBusinessId(id)
-                .orElseThrow(() -> new IllegalArgumentException("Education not found"));
+            List<EducationRelationshipPort.TechStackRelation> relationships =
+                request.getTechStackRelationships() == null
+                    ? List.of()
+                    : request.getTechStackRelationships().stream()
+                        .map(item -> new EducationRelationshipPort.TechStackRelation(
+                            item.getTechStackId(),
+                            item.getIsPrimary() != null ? item.getIsPrimary() : false,
+                            item.getUsageDescription()
+                        ))
+                        .collect(Collectors.toList());
 
-            // 1. 기존 관계 전체 삭제
-            List<EducationTechStackJpaEntity> existingRelations =
-                educationTechStackJpaRepository.findByEducationId(education.getId());
-
-            educationTechStackJpaRepository.deleteAll(existingRelations);
-            log.info("Deleted {} existing tech stack relationships", existingRelations.size());
-
-            // 2. 새 관계 생성
-            if (request.getTechStackRelationships() != null) {
-                for (BulkTechStackRelationshipRequest.TechStackRelationshipItem item : request.getTechStackRelationships()) {
-                    // ID로 기술스택 조회
-                    TechStackMetadataJpaEntity techStack = techStackMetadataJpaRepository
-                        .findById(item.getTechStackId())
-                        .orElseThrow(() -> new IllegalArgumentException(
-                            "TechStack not found: " + item.getTechStackId()));
-
-                    // 새 관계 생성
-                    EducationTechStackJpaEntity relationship = EducationTechStackJpaEntity.builder()
-                        .education(education)
-                        .techStack(techStack)
-                        .isPrimary(item.getIsPrimary() != null ? item.getIsPrimary() : false)
-                        .usageDescription(item.getUsageDescription())
-                        .build();
-
-                    educationTechStackJpaRepository.save(relationship);
-                }
-                log.info("Created {} new tech stack relationships", request.getTechStackRelationships().size());
-            }
+            educationRelationshipPort.replaceTechStacks(id, relationships);
 
             return ResponseEntity.ok(ApiResponse.success(null, "기술스택 관계 일괄 업데이트 성공"));
         } catch (IllegalArgumentException e) {

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/controller/DataController.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/controller/DataController.java
@@ -1,6 +1,7 @@
 package com.aiportfolio.backend.infrastructure.web.controller;
 
 import com.aiportfolio.backend.infrastructure.web.dto.ApiResponse;
+import com.aiportfolio.backend.infrastructure.web.dto.project.ProjectDataResponse;
 import com.aiportfolio.backend.domain.portfolio.model.Certification;
 import com.aiportfolio.backend.domain.portfolio.model.Education;
 import com.aiportfolio.backend.domain.portfolio.model.Experience;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 데이터 웹 컨트롤러 (헥사고날 아키텍처 Infrastructure/Web Layer)
@@ -41,14 +43,27 @@ public class DataController {
     @Operation(summary = "모든 포트폴리오 데이터 조회", description = "프로젝트, 경험, 자격증 등 모든 포트폴리오 데이터를 조회합니다.")
     public ResponseEntity<ApiResponse<Map<String, Object>>> getAllData() {
         Map<String, Object> allData = getAllDataUseCase.getAllPortfolioData();
-        
-        return ResponseEntity.ok(ApiResponse.success(allData, "포트폴리오 데이터 조회 성공"));
+        Map<String, Object> responseData = new java.util.HashMap<>(allData);
+
+        Object projects = allData.get("projects");
+        if (projects instanceof List<?> projectList) {
+            List<ProjectDataResponse> mappedProjects = projectList.stream()
+                .filter(Project.class::isInstance)
+                .map(Project.class::cast)
+                .map(ProjectDataResponse::from)
+                .collect(Collectors.toList());
+            responseData.put("projects", mappedProjects);
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(responseData, "포트폴리오 데이터 조회 성공"));
     }
     
     @GetMapping("/projects")
     @Operation(summary = "프로젝트 데이터 조회", description = "모든 프로젝트 정보를 조회합니다.")
-    public ResponseEntity<ApiResponse<List<Project>>> getProjects() {
-        List<Project> projects = getProjectsUseCase.getAllProjects();
+    public ResponseEntity<ApiResponse<List<ProjectDataResponse>>> getProjects() {
+        List<ProjectDataResponse> projects = getProjectsUseCase.getAllProjects().stream()
+            .map(ProjectDataResponse::from)
+            .collect(Collectors.toList());
         return ResponseEntity.ok(ApiResponse.success(projects, "프로젝트 목록 조회 성공"));
     }
     

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/dto/project/ProjectDataResponse.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/dto/project/ProjectDataResponse.java
@@ -1,0 +1,70 @@
+package com.aiportfolio.backend.infrastructure.web.dto.project;
+
+import com.aiportfolio.backend.domain.portfolio.model.Project;
+import com.aiportfolio.backend.domain.portfolio.model.TechStackMetadata;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Value
+@Builder
+public class ProjectDataResponse {
+    String id;
+    String title;
+    String description;
+    String readme;
+    String type;
+    String source;
+    String status;
+    Integer sortOrder;
+    LocalDate startDate;
+    LocalDate endDate;
+
+    @JsonProperty("isTeam")
+    boolean isTeam;
+
+    Integer teamSize;
+    String role;
+    List<String> myContributions;
+    String githubUrl;
+    String liveUrl;
+    String externalUrl;
+    String imageUrl;
+    List<String> screenshots;
+    List<String> technologies;
+    List<TechStackMetadata> techStackMetadata;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+
+    public static ProjectDataResponse from(Project project) {
+        return ProjectDataResponse.builder()
+                .id(project.getId())
+                .title(project.getTitle())
+                .description(project.getDescription())
+                .readme(project.getReadme())
+                .type(project.getType())
+                .source(project.getSource())
+                .status(project.getStatus())
+                .sortOrder(project.getSortOrder())
+                .startDate(project.getStartDate())
+                .endDate(project.getEndDate())
+                .isTeam(project.isTeam())
+                .teamSize(project.getTeamSize())
+                .role(project.getRole())
+                .myContributions(project.getMyContributions())
+                .githubUrl(project.getGithubUrl())
+                .liveUrl(project.getLiveUrl())
+                .externalUrl(project.getExternalUrl())
+                .imageUrl(project.getImageUrl())
+                .screenshots(project.getScreenshots())
+                .technologies(project.getTechnologies())
+                .techStackMetadata(project.getTechStackMetadata())
+                .createdAt(project.getCreatedAt())
+                .updatedAt(project.getUpdatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the frontend receives the `isTeam` flag consistently in public project payloads. 
- Avoid duplicate-key and race issues when updating tech-stack relationships by switching from destructive delete/insert flows to merge-style updates. 
- Unify relation management across Project, Education, and Experience to reuse the same merge-based contract. 
- Keep controllers thin and delegate relation replacement logic to domain ports/adapters for clearer separation of concerns.

### Description
- Added a new response DTO `ProjectDataResponse` that explicitly serializes `isTeam` via `@JsonProperty("isTeam")` and a static `from(Project)` mapper. 
- Updated `DataController` endpoints (`/api/data/projects` and `/api/data/all`) to map domain `Project` objects to `ProjectDataResponse` before returning JSON. 
- Introduced `ExperienceRelationshipPort` and `ExperienceRelationshipAdapter` implementing a `replaceTechStacks` merge strategy that deletes only removed relations and inserts only new ones. 
- Updated admin controllers `AdminProjectRelationshipController`, `AdminEducationRelationshipController`, and `AdminExperienceRelationshipController` to construct port `TechStackRelation` records from incoming DTOs and call `replaceTechStacks` instead of performing full delete/insert flows.

### Testing
- Attempted to run the backend test suite with `mvn -f backend/pom.xml test`, but the run failed because Maven Central returned a `403` while resolving the `spring-boot-starter-parent` parent POM, so the test phase could not complete. 
- No new automated unit or integration tests were added for `replaceTechStacks` in this change. 
- Static/hygiene checks (compilation/tests) could not be fully verified due to the Maven dependency resolution issue. 
- Recommend running `mvn -f backend/pom.xml test` and the existing backend test suite again in an environment with Maven Central access after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b4b004d848333bbeb435b47b59db2)