### PR TITLE
Fix Redis cache deserialization for projects

### DIFF
--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/CacheConfig.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/CacheConfig.java
@@ -14,8 +14,11 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -33,10 +36,15 @@ public class CacheConfig {
         // 기본 캐시 설정
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
-        
+
         // 날짜 직렬화 설정 개선
-        objectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.setDateFormat(new java.text.SimpleDateFormat("yyyy-MM"));
+        objectMapper.activateDefaultTyping(
+            LaissezFaireSubTypeValidator.instance,
+            ObjectMapper.DefaultTyping.NON_FINAL,
+            JsonTypeInfo.As.PROPERTY
+        );
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
         
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/RedisConfig.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/RedisConfig.java
@@ -1,7 +1,9 @@
 package com.aiportfolio.backend.infrastructure.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +36,11 @@ public class RedisConfig {
         // 날짜 직렬화 설정
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM"));
+        objectMapper.activateDefaultTyping(
+            LaissezFaireSubTypeValidator.instance,
+            ObjectMapper.DefaultTyping.NON_FINAL,
+            JsonTypeInfo.As.PROPERTY
+        );
 
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/controller/DataController.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/web/controller/DataController.java
@@ -63,7 +63,8 @@ public class DataController {
     @GetMapping("/projects")
     @Operation(summary = "프로젝트 데이터 조회", description = "모든 프로젝트 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<List<ProjectDataResponse>>> getProjects() {
-        List<ProjectDataResponse> projects = getProjectsUseCase.getAllProjects().stream()
+        List<?> rawProjects = getProjectsUseCase.getAllProjects();
+        List<ProjectDataResponse> projects = rawProjects.stream()
             .map(this::toProjectResponse)
             .collect(Collectors.toList());
         return ResponseEntity.ok(ApiResponse.success(projects, "프로젝트 목록 조회 성공"));


### PR DESCRIPTION
### Motivation
- Prevent `ClassCastException` when Redis-cached project entries deserialize as `LinkedHashMap` instead of domain `Project` objects.  
- Ensure cached values serialized to Redis retain type information so Jackson can restore domain types.  
- Make the projects endpoint resilient to cached, untyped payloads returned by repository/cache layers.  

### Description
- Activate Jackson polymorphic typing on cache and Redis `ObjectMapper`s by calling `activateDefaultTyping(..., ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY)` in `CacheConfig` and `RedisConfig`.  
- Use a `GenericJackson2JsonRedisSerializer` backed by the typed `ObjectMapper` for Redis cache/`RedisTemplate` value serialization.  
- Make `DataController#getProjects()` read `List<?> rawProjects = getProjectsUseCase.getAllProjects()` and then map items via the existing `toProjectResponse` converter to tolerate `Map` instances.  
- Add required imports (`JsonTypeInfo`, `LaissezFaireSubTypeValidator`, `SerializationFeature`) and minor wiring adjustments to support the above changes.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694baea3679883339fe4e7673544036b)