### PR TITLE
refactor(E02): redis serialization and cache keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ SonarQube 품질 작업과 코드 수정 시 **프로젝트 로컬** `.cursor/sk
 - **원본:** `.cursor/skills/<name>/SKILL.md`
 - **품질·Sonar:** `local-sonarqube-agent-workflow` — basis `docs/basis/quality/SQ-01-local-sonarqube-workflow.md`
 - **이슈 배치 처리:** `docs/issues/sonarqube/sonarqube-issue-handling-guideline.md` (**SQ-02**)
+- **에픽/아키텍처 검토 (vibe_boilerplate에서 복제):** `epic-architecture-review`, `pt-01-domain-modeling`, `pt-02-implementation-patterns`
+- **파일 단위 basis 검토:** `file-basis-review`, `cc-02-method-level`, `cc-05-code-hygiene`
 
 ## Suggested routing
 
@@ -16,6 +18,8 @@ SonarQube 품질 작업과 코드 수정 시 **프로젝트 로컬** `.cursor/sk
 4. 의미 있는 변경 단위 후 → **`request-code-review`**
 5. 프론트 구현·리뷰 → `react-stack` / `typescript-stack`(Cursor에 복제한 경우)
 6. 백엔드 → `spring-boot-stack` / `java-stack`(복제한 경우)
+7. 에픽 설계 검토·종료 전 아키텍처 감사 → `epic-architecture-review` → 필요 시 `pt-01-domain-modeling`, `pt-02-implementation-patterns`
+8. 변경/리뷰 단위 파일 감사 → `file-basis-review` + `cc-02-method-level` + `cc-05-code-hygiene` (레이어에 맞게 선택)
 
 보일러플레이트 `vibe_boilerplate` 에서 스택 스킬·추가 워크플로를 가져올 때는 `AGENTS.md` 와 이 라우팅 표를 함께 맞춘다.
 

--- a/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageCertificationService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageCertificationService.java
@@ -7,6 +7,7 @@ import com.aiportfolio.backend.application.common.util.TextFieldHelper;
 import com.aiportfolio.backend.domain.portfolio.model.Certification;
 import com.aiportfolio.backend.domain.portfolio.port.in.ManageCertificationUseCase;
 import com.aiportfolio.backend.domain.portfolio.port.out.PortfolioRepositoryPort;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -31,7 +32,7 @@ public class ManageCertificationService implements ManageCertificationUseCase {
     private final SortOrderService sortOrderService;
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.CERTIFICATIONS_ALL + "'")
     public Certification createCertification(Certification certification) {
         log.info("Creating new certification: {}", certification.getName());
 
@@ -68,7 +69,7 @@ public class ManageCertificationService implements ManageCertificationUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.CERTIFICATIONS_ALL + "'")
     public Certification updateCertification(String id, Certification certification) {
         log.info("Updating certification: {}", id);
 
@@ -101,7 +102,7 @@ public class ManageCertificationService implements ManageCertificationUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.CERTIFICATIONS_ALL + "'")
     public void deleteCertification(String id) {
         log.info("Deleting certification: {}", id);
 
@@ -115,7 +116,7 @@ public class ManageCertificationService implements ManageCertificationUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.CERTIFICATIONS_ALL + "'")
     public void updateCertificationSortOrder(Map<String, Integer> sortOrderUpdates) {
         log.info("Updating certification sort orders: {} items", sortOrderUpdates.size());
 

--- a/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageEducationService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageEducationService.java
@@ -12,6 +12,7 @@ import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.Educat
 import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.ProjectJpaEntity;
 import com.aiportfolio.backend.infrastructure.persistence.postgres.repository.EducationJpaRepository;
 import com.aiportfolio.backend.infrastructure.persistence.postgres.repository.ProjectJpaRepository;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -56,7 +57,7 @@ public class ManageEducationService implements ManageEducationUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EDUCATIONS_ALL + "'")
     public Education createEducation(Education education) {
         log.info("Creating new education: {}", education.getTitle());
 
@@ -92,7 +93,7 @@ public class ManageEducationService implements ManageEducationUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EDUCATIONS_ALL + "'")
     public Education updateEducation(String id, Education education) {
         log.info("Updating education: {}", id);
 
@@ -124,7 +125,7 @@ public class ManageEducationService implements ManageEducationUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EDUCATIONS_ALL + "'")
     public void deleteEducation(String id) {
         log.info("Deleting education: {}", id);
 
@@ -168,7 +169,7 @@ public class ManageEducationService implements ManageEducationUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EDUCATIONS_ALL + "'")
     public void updateEducationSortOrder(Map<String, Integer> sortOrderUpdates) {
         log.info("Updating education sort orders: {} items", sortOrderUpdates.size());
 

--- a/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageExperienceService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageExperienceService.java
@@ -7,6 +7,7 @@ import com.aiportfolio.backend.application.common.util.TextFieldHelper;
 import com.aiportfolio.backend.domain.portfolio.model.Experience;
 import com.aiportfolio.backend.domain.portfolio.port.in.ManageExperienceUseCase;
 import com.aiportfolio.backend.domain.portfolio.port.out.PortfolioRepositoryPort;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -31,7 +32,7 @@ public class ManageExperienceService implements ManageExperienceUseCase {
     private final SortOrderService sortOrderService;
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EXPERIENCES_ALL + "'")
     public Experience createExperience(Experience experience) {
         log.info("Creating new experience: {}", experience.getTitle());
 
@@ -69,7 +70,7 @@ public class ManageExperienceService implements ManageExperienceUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EXPERIENCES_ALL + "'")
     public Experience updateExperience(String id, Experience experience) {
         log.info("Updating experience: {}", id);
 
@@ -103,7 +104,7 @@ public class ManageExperienceService implements ManageExperienceUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EXPERIENCES_ALL + "'")
     public void deleteExperience(String id) {
         log.info("Deleting experience: {}", id);
 
@@ -117,7 +118,7 @@ public class ManageExperienceService implements ManageExperienceUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EXPERIENCES_ALL + "'")
     public void updateExperienceSortOrder(Map<String, Integer> sortOrderUpdates) {
         log.info("Updating experience sort orders: {} items", sortOrderUpdates.size());
 

--- a/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageProjectService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageProjectService.java
@@ -16,6 +16,7 @@ import com.aiportfolio.backend.domain.portfolio.port.out.ProjectRelationshipPort
 import com.aiportfolio.backend.domain.portfolio.port.out.TechStackMetadataRepositoryPort;
 import com.aiportfolio.backend.infrastructure.persistence.postgres.entity.ProjectJpaEntity;
 import com.aiportfolio.backend.infrastructure.persistence.postgres.repository.ProjectJpaRepository;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -86,7 +87,7 @@ public class ManageProjectService implements ManageProjectUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public Project createProject(ProjectCreateCommand command) {
         log.info("Creating new project: {}", command.getTitle());
 
@@ -133,7 +134,7 @@ public class ManageProjectService implements ManageProjectUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public Project updateProject(String id, ProjectUpdateCommand command) {
         log.info("Updating project: {}", id);
 
@@ -274,7 +275,7 @@ public class ManageProjectService implements ManageProjectUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public void deleteProject(String id) {
         log.info("Deleting project: {}", id);
 

--- a/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageTechStackMetadataService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/admin/service/ManageTechStackMetadataService.java
@@ -4,6 +4,7 @@ import com.aiportfolio.backend.domain.portfolio.model.TechStackMetadata;
 import com.aiportfolio.backend.domain.portfolio.port.in.ManageTechStackMetadataUseCase;
 import com.aiportfolio.backend.domain.portfolio.port.out.TechStackMetadataRepositoryPort;
 import com.aiportfolio.backend.domain.portfolio.service.TechStackDomainService;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -26,7 +27,7 @@ public class ManageTechStackMetadataService implements ManageTechStackMetadataUs
     private final TechStackDomainService techStackDomainService;
     
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public TechStackMetadata createTechStackMetadata(TechStackMetadata techStackMetadata) {
         // 도메인 서비스를 통한 비즈니스 로직 검증
         techStackDomainService.validateForCreation(techStackMetadata);
@@ -39,7 +40,7 @@ public class ManageTechStackMetadataService implements ManageTechStackMetadataUs
     }
     
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public TechStackMetadata updateTechStackMetadata(String name, TechStackMetadata techStackMetadata) {
         // 도메인 서비스를 통한 비즈니스 로직 검증
         techStackDomainService.validateForUpdate(name, techStackMetadata);
@@ -49,7 +50,7 @@ public class ManageTechStackMetadataService implements ManageTechStackMetadataUs
     }
     
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public void deleteTechStackMetadata(String name) {
         if (!techStackMetadataRepositoryPort.existsByName(name)) {
             throw new IllegalArgumentException("존재하지 않는 기술명입니다: " + name);
@@ -59,7 +60,7 @@ public class ManageTechStackMetadataService implements ManageTechStackMetadataUs
     }
     
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public TechStackMetadata toggleTechStackMetadataStatus(String name) {
         return techStackMetadataRepositoryPort.findByName(name)
             .map(techStack -> {

--- a/backend/src/main/java/com/aiportfolio/backend/application/admin/service/UpdateTechStackSortOrderService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/admin/service/UpdateTechStackSortOrderService.java
@@ -3,6 +3,7 @@ package com.aiportfolio.backend.application.admin.service;
 import com.aiportfolio.backend.domain.portfolio.model.TechStackMetadata;
 import com.aiportfolio.backend.domain.portfolio.port.in.UpdateTechStackSortOrderUseCase;
 import com.aiportfolio.backend.domain.portfolio.port.out.TechStackMetadataRepositoryPort;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -30,7 +31,7 @@ public class UpdateTechStackSortOrderService implements UpdateTechStackSortOrder
     private final TechStackMetadataRepositoryPort techStackMetadataRepositoryPort;
     
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public List<TechStackMetadata> updateSortOrder(String techStackName, int newSortOrder) {
         log.info("기술스택 '{}'의 정렬 순서를 {}로 변경", techStackName, newSortOrder);
         
@@ -62,7 +63,7 @@ public class UpdateTechStackSortOrderService implements UpdateTechStackSortOrder
     }
     
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public List<TechStackMetadata> updateSortOrders(List<SortOrderUpdate> sortOrderUpdates) {
         log.info("{}개 기술스택의 정렬 순서 일괄 업데이트", sortOrderUpdates.size());
         

--- a/backend/src/main/java/com/aiportfolio/backend/application/article/ManageArticleService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/article/ManageArticleService.java
@@ -7,6 +7,7 @@ import com.aiportfolio.backend.domain.article.port.in.ManageArticleSeriesUseCase
 import com.aiportfolio.backend.domain.article.port.out.ArticleRepositoryPort;
 import com.aiportfolio.backend.domain.article.port.out.ArticleSeriesRepositoryPort;
 import com.aiportfolio.backend.infrastructure.persistence.postgres.repository.ProjectJpaRepository;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -29,7 +30,7 @@ public class ManageArticleService implements ManageArticleUseCase {
     private final ProjectJpaRepository projectJpaRepository;
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public Article create(CreateArticleCommand command) {
         // 비즈니스 ID 생성
         String businessId = articleRepository.generateNextBusinessId();
@@ -96,7 +97,7 @@ public class ManageArticleService implements ManageArticleUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public Article update(UpdateArticleCommand command) {
         // 기존 Article 조회
         Article existing = articleRepository.findById(command.id())
@@ -185,7 +186,7 @@ public class ManageArticleService implements ManageArticleUseCase {
     }
 
     @Override
-    @CacheEvict(value = "portfolio", allEntries = true)
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public void delete(Long id) {
         articleRepository.delete(id);
     }

--- a/backend/src/main/java/com/aiportfolio/backend/application/portfolio/GitHubIntegrationService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/portfolio/GitHubIntegrationService.java
@@ -1,6 +1,7 @@
 package com.aiportfolio.backend.application.portfolio;
 
 import com.aiportfolio.backend.infrastructure.config.AppConfig;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 import com.aiportfolio.backend.domain.portfolio.model.Project;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,7 @@ public class GitHubIntegrationService {
     
     private static final String GITHUB_API_BASE = "https://api.github.com";
     
-    @Cacheable(value = "github", key = "'projects'")
+    @Cacheable(value = CacheKeys.GITHUB, key = "'" + CacheKeys.GITHUB_PROJECTS + "'")
     public List<Project> getPortfolioProjects() {
         try {
             String username = appConfig.getGitHub().getUsername();
@@ -52,7 +53,7 @@ public class GitHubIntegrationService {
         }
     }
     
-    @Cacheable(value = "github", key = "'project:' + #repoName")
+    @Cacheable(value = CacheKeys.GITHUB, key = "'" + CacheKeys.GITHUB_PROJECT_PREFIX + "' + #repoName")
     public Project getProjectInfo(String repoName) {
         try {
             String username = appConfig.getGitHub().getUsername();

--- a/backend/src/main/java/com/aiportfolio/backend/application/portfolio/PortfolioService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/portfolio/PortfolioService.java
@@ -8,12 +8,14 @@ import com.aiportfolio.backend.domain.portfolio.model.Certification;
 import com.aiportfolio.backend.domain.portfolio.model.Education;
 import com.aiportfolio.backend.domain.portfolio.model.Experience;
 import com.aiportfolio.backend.domain.portfolio.model.Project;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -59,8 +61,8 @@ public class PortfolioService implements GetAllDataUseCase, GetProjectsUseCase, 
     
     @Override
     @Cacheable(
-        value = "portfolio",
-        key = "'experiences:all'",
+        value = CacheKeys.PORTFOLIO,
+        key = "'" + CacheKeys.EXPERIENCES_ALL + "'",
         unless = "#result == null || #result.isEmpty()"
     )
     public List<Experience> getAllExperiences() {
@@ -72,8 +74,8 @@ public class PortfolioService implements GetAllDataUseCase, GetProjectsUseCase, 
     
     @Override
     @Cacheable(
-        value = "portfolio",
-        key = "'educations:all'",
+        value = CacheKeys.PORTFOLIO,
+        key = "'" + CacheKeys.EDUCATIONS_ALL + "'",
         unless = "#result == null || #result.isEmpty()"
     )
     public List<Education> getAllEducations() {
@@ -85,8 +87,8 @@ public class PortfolioService implements GetAllDataUseCase, GetProjectsUseCase, 
     
     @Override
     @Cacheable(
-        value = "portfolio",
-        key = "'certifications:all'",
+        value = CacheKeys.PORTFOLIO,
+        key = "'" + CacheKeys.CERTIFICATIONS_ALL + "'",
         unless = "#result == null || #result.isEmpty()"
     )
     public List<Certification> getAllCertifications() {
@@ -100,8 +102,8 @@ public class PortfolioService implements GetAllDataUseCase, GetProjectsUseCase, 
     
     @Override
     @Cacheable(
-        value = "portfolio",
-        key = "'projects:all'",
+        value = CacheKeys.PORTFOLIO,
+        key = "'" + CacheKeys.PROJECTS_ALL + "'",
         unless = "#result == null || #result.isEmpty()"
     )
     public List<Project> getAllProjects() {
@@ -159,13 +161,16 @@ public class PortfolioService implements GetAllDataUseCase, GetProjectsUseCase, 
     // === ManageProjectCacheUseCase 구현 ===
     
     @Override
-    @CacheEvict(value = "portfolio", key = "'projects:all'")
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public void refreshProjectsCache() {
         log.info("프로젝트 캐시 무효화");
     }
 
     @Override
-    @CacheEvict(value = {"portfolio", "github"}, allEntries = true)
+    @Caching(evict = {
+        @CacheEvict(value = CacheKeys.PORTFOLIO, allEntries = true),
+        @CacheEvict(value = CacheKeys.GITHUB, allEntries = true)
+    })
     public void refreshCache() {
         log.info("전체 포트폴리오 캐시 무효화");
     }

--- a/backend/src/main/java/com/aiportfolio/backend/application/portfolio/ProjectApplicationService.java
+++ b/backend/src/main/java/com/aiportfolio/backend/application/portfolio/ProjectApplicationService.java
@@ -4,9 +4,11 @@ import com.aiportfolio.backend.domain.portfolio.port.in.GetProjectsUseCase;
 import com.aiportfolio.backend.domain.portfolio.port.in.ManageProjectCacheUseCase;
 import com.aiportfolio.backend.domain.portfolio.port.out.PortfolioRepositoryPort;
 import com.aiportfolio.backend.domain.portfolio.model.Project;
+import com.aiportfolio.backend.infrastructure.config.CacheKeys;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -77,13 +79,16 @@ public class ProjectApplicationService implements GetProjectsUseCase, ManageProj
     }
     
     @Override
-    @CacheEvict(value = "portfolio", key = "'projects:all'")
+    @CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.PROJECTS_ALL + "'")
     public void refreshProjectsCache() {
         log.info("프로젝트 캐시 무효화");
     }
 
     @Override
-    @CacheEvict(value = {"portfolio", "github"}, allEntries = true)
+    @Caching(evict = {
+        @CacheEvict(value = CacheKeys.PORTFOLIO, allEntries = true),
+        @CacheEvict(value = CacheKeys.GITHUB, allEntries = true)
+    })
     public void refreshCache() {
         log.info("전체 포트폴리오 캐시 무효화");
     }

--- a/backend/src/main/java/com/aiportfolio/backend/domain/monitoring/model/CloudUsage.java
+++ b/backend/src/main/java/com/aiportfolio/backend/domain/monitoring/model/CloudUsage.java
@@ -1,7 +1,9 @@
 package com.aiportfolio.backend.domain.monitoring.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -13,6 +15,8 @@ import java.util.List;
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CloudUsage {
     private CloudProvider provider;
     private BigDecimal totalCost;

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/cache/RedisCloudUsageCacheAdapter.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/cache/RedisCloudUsageCacheAdapter.java
@@ -3,7 +3,6 @@ package com.aiportfolio.backend.infrastructure.cache;
 import com.aiportfolio.backend.domain.monitoring.model.CloudProvider;
 import com.aiportfolio.backend.domain.monitoring.model.CloudUsage;
 import com.aiportfolio.backend.domain.monitoring.port.out.CloudUsageCachePort;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -22,17 +21,14 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class RedisCloudUsageCacheAdapter implements CloudUsageCachePort {
 
-    private final RedisTemplate<String, String> redisTemplate;
-    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public void saveUsage(String key, CloudUsage usage, long ttlSeconds) {
         try {
-            String json = objectMapper.writeValueAsString(usage);
-            redisTemplate.opsForValue().set(key, json, ttlSeconds, TimeUnit.SECONDS);
+            redisTemplate.opsForValue().set(key, usage, ttlSeconds, TimeUnit.SECONDS);
             log.debug("Cached cloud usage: key={}, ttl={}s", key, ttlSeconds);
         } catch (Exception e) {
-            // 캐시 실패는 조용히 처리 (fallback to API)
             log.warn("Failed to cache cloud usage: key={}", key, e);
         }
     }
@@ -40,13 +36,16 @@ public class RedisCloudUsageCacheAdapter implements CloudUsageCachePort {
     @Override
     public CloudUsage getUsage(String key) {
         try {
-            String json = redisTemplate.opsForValue().get(key);
-            if (json == null) {
+            Object raw = redisTemplate.opsForValue().get(key);
+            if (raw == null) {
                 return null;
             }
-            CloudUsage usage = objectMapper.readValue(json, CloudUsage.class);
-            log.debug("Retrieved cloud usage from cache: key={}", key);
-            return usage;
+            if (raw instanceof CloudUsage usage) {
+                log.debug("Retrieved cloud usage from cache: key={}", key);
+                return usage;
+            }
+            log.warn("Unexpected type for cloud usage cache: key={}, type={}", key, raw.getClass().getName());
+            return null;
         } catch (Exception e) {
             log.warn("Failed to retrieve cloud usage from cache: key={}", key, e);
             return null;
@@ -68,9 +67,7 @@ public class RedisCloudUsageCacheAdapter implements CloudUsageCachePort {
     public void saveDailyUsage(CloudProvider provider, LocalDate date, CloudUsage usage) {
         try {
             String key = generateDailyKey(provider, date);
-            String json = objectMapper.writeValueAsString(usage);
-            // 90일 TTL로 저장 (히스토리 데이터)
-            redisTemplate.opsForValue().set(key, json, 90, TimeUnit.DAYS);
+            redisTemplate.opsForValue().set(key, usage, 90, TimeUnit.DAYS);
             log.debug("Saved daily usage: key={}, date={}", key, date);
         } catch (Exception e) {
             log.warn("Failed to save daily usage: provider={}, date={}", provider, date, e);
@@ -81,13 +78,16 @@ public class RedisCloudUsageCacheAdapter implements CloudUsageCachePort {
     public CloudUsage getDailyUsage(CloudProvider provider, LocalDate date) {
         try {
             String key = generateDailyKey(provider, date);
-            String json = redisTemplate.opsForValue().get(key);
-            if (json == null) {
+            Object raw = redisTemplate.opsForValue().get(key);
+            if (raw == null) {
                 return null;
             }
-            CloudUsage usage = objectMapper.readValue(json, CloudUsage.class);
-            log.debug("Retrieved daily usage: key={}", key);
-            return usage;
+            if (raw instanceof CloudUsage usage) {
+                log.debug("Retrieved daily usage: key={}", key);
+                return usage;
+            }
+            log.warn("Unexpected type for daily cloud usage cache: key={}, type={}", key, raw.getClass().getName());
+            return null;
         } catch (Exception e) {
             log.warn("Failed to retrieve daily usage: provider={}, date={}", provider, date, e);
             return null;
@@ -104,20 +104,16 @@ public class RedisCloudUsageCacheAdapter implements CloudUsageCachePort {
                     usages.add(usage);
                 }
             }
-            log.debug("Retrieved daily usage range: provider={}, start={}, end={}, count={}", 
+            log.debug("Retrieved daily usage range: provider={}, start={}, end={}, count={}",
                 provider, startDate, endDate, usages.size());
         } catch (Exception e) {
-            log.warn("Failed to retrieve daily usage range: provider={}, start={}, end={}", 
+            log.warn("Failed to retrieve daily usage range: provider={}, start={}, end={}",
                 provider, startDate, endDate, e);
         }
         return usages;
     }
 
-    /**
-     * 날짜별 키 생성
-     */
     private String generateDailyKey(CloudProvider provider, LocalDate date) {
         return String.format("cloud_usage:daily:%s:%s", provider.name(), date);
     }
 }
-

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/CacheConfig.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/CacheConfig.java
@@ -1,6 +1,8 @@
 package com.aiportfolio.backend.infrastructure.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -14,9 +16,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -30,22 +29,13 @@ public class CacheConfig {
 
     @Bean
     @Primary
-    public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
-        /*
-         * 수동 ObjectMapper.activateDefaultTyping(...) 과 GenericJackson2JsonRedisSerializer 조합은
-         * Jackson이 루트 컬렉션에 WRAPPER_ARRAY 역직렬화를 기대하는 경우가 있어
-         * PROPERTY 형태로 저장된 캐시([{"@class":...},...])와 충돌할 수 있다.
-         * Spring Data Redis가 내부 ObjectMapper에 적용하는 TypeResolverBuilder(PROPERTY)와
-         * configure()로만 JSR-310 등을 맞춘다.
-         */
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
-        serializer.configure(om -> {
-            om.registerModule(new JavaTimeModule());
-            om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-            om.setDateFormat(new java.text.SimpleDateFormat("yyyy-MM"));
-            om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        });
-        
+    public CacheManager redisCacheManager(
+        RedisConnectionFactory connectionFactory,
+        @Qualifier("redisObjectMapper") ObjectMapper redisObjectMapper
+    ) {
+        GenericJackson2JsonRedisSerializer serializer =
+            new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
             .entryTtl(Duration.ofHours(1)) // 기본 1시간
             .serializeKeysWith(RedisSerializationContext.SerializationPair
@@ -58,11 +48,11 @@ public class CacheConfig {
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
         
         // 포트폴리오 데이터: 1일 캐시
-        cacheConfigurations.put("portfolio", defaultConfig
+        cacheConfigurations.put(CacheKeys.PORTFOLIO, defaultConfig
             .entryTtl(Duration.ofDays(1)));
         
         // GitHub API: 30분 캐시
-        cacheConfigurations.put("github", defaultConfig
+        cacheConfigurations.put(CacheKeys.GITHUB, defaultConfig
             .entryTtl(Duration.ofMinutes(30)));
 
         return RedisCacheManager.builder(connectionFactory)
@@ -75,7 +65,7 @@ public class CacheConfig {
     @ConditionalOnMissingBean(CacheManager.class)
     public CacheManager memoryCacheManager() {
         ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
-        cacheManager.setCacheNames(Arrays.asList("portfolio", "github"));
+        cacheManager.setCacheNames(Arrays.asList(CacheKeys.PORTFOLIO, CacheKeys.GITHUB));
         return cacheManager;
     }
 }

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/CacheKeys.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/CacheKeys.java
@@ -1,0 +1,23 @@
+package com.aiportfolio.backend.infrastructure.config;
+
+/**
+ * Spring Cache 이름 및 Redis 캐시 엔트리 키(SpEL과 동일한 문자열 값) 상수.
+ */
+public final class CacheKeys {
+
+    private CacheKeys() {
+    }
+
+    public static final String PORTFOLIO = "portfolio";
+    public static final String GITHUB = "github";
+
+    public static final String EXPERIENCES_ALL = "experiences:all";
+    public static final String EDUCATIONS_ALL = "educations:all";
+    public static final String CERTIFICATIONS_ALL = "certifications:all";
+    public static final String PROJECTS_ALL = "projects:all";
+
+    public static final String GITHUB_PROJECTS = "projects";
+    public static final String GITHUB_PROJECT_PREFIX = "project:";
+
+    public static final String FRONTEND_CACHE_VERSION = "frontend:cache:version";
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/RedisConfig.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/RedisConfig.java
@@ -1,8 +1,7 @@
 package com.aiportfolio.backend.infrastructure.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -10,8 +9,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
-
-import java.text.SimpleDateFormat;
 
 /**
  * Redis 설정 클래스
@@ -26,14 +23,12 @@ public class RedisConfig {
      * 캐시 데이터를 위한 직렬화 설정을 포함합니다.
      */
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
-        serializer.configure(om -> {
-            om.registerModule(new JavaTimeModule());
-            om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-            om.setDateFormat(new SimpleDateFormat("yyyy-MM"));
-            om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        });
+    public RedisTemplate<String, Object> redisTemplate(
+        RedisConnectionFactory connectionFactory,
+        @Qualifier("redisObjectMapper") ObjectMapper redisObjectMapper
+    ) {
+        GenericJackson2JsonRedisSerializer serializer =
+            new GenericJackson2JsonRedisSerializer(redisObjectMapper);
 
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/RedisObjectMapperConfig.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/config/RedisObjectMapperConfig.java
@@ -1,0 +1,30 @@
+package com.aiportfolio.backend.infrastructure.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.text.SimpleDateFormat;
+
+@Configuration
+public class RedisObjectMapperConfig {
+
+    @Bean("redisObjectMapper")
+    public ObjectMapper redisObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM"));
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.activateDefaultTyping(
+            mapper.getPolymorphicTypeValidator(),
+            ObjectMapper.DefaultTyping.NON_FINAL,
+            JsonTypeInfo.As.PROPERTY
+        );
+        return mapper;
+    }
+}

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/redis/adapter/RedisCacheManagementAdapter.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/redis/adapter/RedisCacheManagementAdapter.java
@@ -231,12 +231,14 @@ public class RedisCacheManagementAdapter implements CacheManagementPort {
             collectKeysUsingScan(options, keys);
 
         } catch (Exception e) {
-            log.error("Error scanning keys with pattern: {}. Error: {}", pattern, e.getMessage(), e);
-            // SCAN 실패 시 keys() 명령어로 fallback (경고 로그와 함께)
-            log.warn("Falling back to keys() command due to SCAN failure. This may cause performance issues.");
-            return fallbackKeys(pattern);
+            log.error(
+                "SCAN failed for pattern: {}. KEYS fallback is not used (Redis Cloud / managed Redis compatibility).",
+                pattern,
+                e
+            );
+            return Collections.emptySet();
         }
-        
+
         return keys;
     }
 
@@ -292,17 +294,6 @@ public class RedisCacheManagementAdapter implements CacheManagementPort {
         }
     }
 
-    private Set<String> fallbackKeys(String pattern) {
-        try {
-            Set<String> fallbackKeys = redisTemplate.keys(pattern);
-            log.info("Fallback keys() command succeeded. Found {} keys", fallbackKeys != null ? fallbackKeys.size() : 0);
-            return fallbackKeys != null ? fallbackKeys : Collections.emptySet();
-        } catch (Exception fallbackException) {
-            log.error("Fallback keys() command also failed. Error: {}", fallbackException.getMessage(), fallbackException);
-            throw new IllegalStateException("키 조회 중 오류가 발생했습니다", fallbackException);
-        }
-    }
-    
     /**
      * Redis 메모리 정보 조회
      */

--- a/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/redis/adapter/RedisRateLimitStorageAdapter.java
+++ b/backend/src/main/java/com/aiportfolio/backend/infrastructure/persistence/redis/adapter/RedisRateLimitStorageAdapter.java
@@ -8,7 +8,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -46,24 +45,6 @@ public class RedisRateLimitStorageAdapter implements RateLimitStoragePort {
             return null;
         }
         if (raw instanceof SpamSubmissionRecord r) {
-            return r;
-        }
-        if (raw instanceof Map<?, ?> map) {
-            SpamSubmissionRecord r = new SpamSubmissionRecord();
-            Object countObj = map.get("count");
-            Object lastObj = map.get("lastSubmission");
-            Object blockedObj = map.get("blockedUntil");
-            if (countObj instanceof Number n) {
-                r.setCount(n.intValue());
-            }
-            if (lastObj instanceof Number n) {
-                r.setLastSubmission(n.longValue());
-            }
-            if (blockedObj instanceof Number n) {
-                r.setBlockedUntil(n.longValue());
-            } else {
-                r.setBlockedUntil(null);
-            }
             return r;
         }
         log.warn("Unexpected Redis value type for spam record: {}", raw.getClass().getName());

--- a/backend/src/main/resources/application-staging.yml
+++ b/backend/src/main/resources/application-staging.yml
@@ -48,9 +48,11 @@ spring:
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
       database: ${REDIS_DATABASE}
+      # Redis Cloud: TLS는 REDIS_SSL=true 등 환경 변수로 제어
       ssl:
         enabled: ${REDIS_SSL}
-      timeout: 10000ms  # SCAN 명령어 사용 시 타임아웃 증가 (10초)
+      # SCAN만 사용(E02); production/local과 유사한 명령 대기 시간으로 통일
+      timeout: 3000ms
       lettuce:
         pool:
           max-active: 8

--- a/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P01-objectmapper-centralization.md
+++ b/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P01-objectmapper-centralization.md
@@ -1,0 +1,111 @@
+# P01: ObjectMapper 중앙화 및 직렬화 설정 통합
+
+## 목표
+
+`RedisConfig`와 `CacheConfig`가 각각 독립적으로 생성하던 `GenericJackson2JsonRedisSerializer` 인스턴스를
+하나의 `@Bean ObjectMapper`를 공유하도록 변경하여 직렬화 설정 불일치를 근본 제거한다.
+
+## 문제 상세
+
+### 현재 구조
+```
+RedisConfig.java
+  └─ new GenericJackson2JsonRedisSerializer()
+       └─ .configure(om -> { JavaTimeModule, ... })  ← 내부 ObjectMapper A
+
+CacheConfig.java
+  └─ new GenericJackson2JsonRedisSerializer()
+       └─ .configure(om -> { JavaTimeModule, ... })  ← 내부 ObjectMapper B (다른 인스턴스)
+```
+
+두 `configure()` 람다가 동일해 보여도 인스턴스가 다르므로, 향후 한 쪽만 수정되면 즉시 직렬화 불일치 발생.
+`GenericJackson2JsonRedisSerializer(ObjectMapper)` 생성자를 사용하면 외부에서 주입한 ObjectMapper를 그대로 사용하므로 공유 가능하다.
+
+### `configure()` vs 생성자 주입 차이
+- `configure(om -> ...)`: 내부적으로 이미 defaultTyping이 설정된 ObjectMapper를 람다로 수정 — DefaultTyping 설정을 덮어쓸 위험 없음
+- `new GenericJackson2JsonRedisSerializer(objectMapper)`: 외부 ObjectMapper를 그대로 사용 — **activateDefaultTyping을 직접 설정해야 함**
+
+따라서 생성자 주입 방식을 선택할 경우 ObjectMapper 빈에 `activateDefaultTyping(PROPERTY)` 적용이 필수다.
+
+## 구현 상세
+
+### 1. Redis 전용 ObjectMapper 빈 추출
+
+**새 파일 생성:**  
+`backend/src/main/java/com/aiportfolio/backend/infrastructure/config/RedisObjectMapperConfig.java`
+
+```java
+@Configuration
+public class RedisObjectMapperConfig {
+
+    @Bean("redisObjectMapper")
+    public ObjectMapper redisObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM"));
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        // GenericJackson2JsonRedisSerializer가 내부적으로 적용하는 것과 동일한 타입 설정
+        mapper.activateDefaultTyping(
+            mapper.getPolymorphicTypeValidator(),
+            ObjectMapper.DefaultTyping.NON_FINAL,
+            JsonTypeInfo.As.PROPERTY
+        );
+        return mapper;
+    }
+}
+```
+
+**주의:** `@Primary` 지정 금지 — Spring MVC의 기본 ObjectMapper와 분리 유지.
+
+### 2. RedisConfig 수정
+
+**변경 파일:** `infrastructure/config/RedisConfig.java`
+
+```java
+// Before
+GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+serializer.configure(om -> { ... });
+
+// After
+@Autowired @Qualifier("redisObjectMapper")
+private ObjectMapper redisObjectMapper;
+
+GenericJackson2JsonRedisSerializer serializer =
+    new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+```
+
+### 3. CacheConfig 수정
+
+**변경 파일:** `infrastructure/config/CacheConfig.java`
+
+```java
+// redisCacheManager 메서드 파라미터에 ObjectMapper 추가
+@Bean
+@Primary
+public CacheManager redisCacheManager(
+    RedisConnectionFactory connectionFactory,
+    @Qualifier("redisObjectMapper") ObjectMapper redisObjectMapper
+) {
+    GenericJackson2JsonRedisSerializer serializer =
+        new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+    // 나머지 동일
+}
+```
+
+### 4. CacheConfig 주석 제거
+
+현재 "WRAPPER_ARRAY vs PROPERTY 충돌" 주석은 `configure()` 람다 방식의 주의사항이었으므로,
+생성자 주입으로 교체 후 해당 주석 삭제.
+
+## 완료 기준 (체크리스트)
+
+- [x] `RedisObjectMapperConfig.java` 생성, `@Bean("redisObjectMapper")` 정의
+- [x] `RedisConfig`: `configure()` 람다 제거, `@Qualifier("redisObjectMapper")` 주입으로 교체
+- [x] `CacheConfig`: `configure()` 람다 제거, 메서드 파라미터로 `redisObjectMapper` 주입
+- [x] `CacheConfig`의 WRAPPER_ARRAY/PROPERTY 관련 주석 제거
+- [x] Docker `backend` 컨테이너에서 `mvn compile`·`mvn test` 성공 (AGENTS.md)
+- [x] Redis/캐시 직렬화 회귀 방지: `RedisSerializationConfigIntegrationTest` (`redisObjectMapper` 빈, `RedisTemplate`·`CacheManager` 라운드트립)
+- [ ] 로컬 실행 후 `/api/portfolio` 호출 → Redis에 캐시 저장 확인 (Admin 캐시 키 조회)
+- [ ] 캐시 저장 후 재조회 시 역직렬화 오류 없음 확인
+- [ ] P02 착수 전 Redis 전체 플러시 (`POST /api/admin/cache/flush`) 실행 권고

--- a/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P02-adapter-serialization-consistency.md
+++ b/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P02-adapter-serialization-consistency.md
@@ -1,0 +1,141 @@
+# P02: 어댑터 직렬화 일관성 확보
+
+## 전제 조건
+
+**P01 완료 후 착수.** P01에서 확립한 `redisObjectMapper` 빈을 이 Phase에서도 활용한다.
+
+## 목표
+
+`RedisCloudUsageCacheAdapter`와 `RedisRateLimitStorageAdapter`의 직렬화 방식을
+P01에서 통일한 `GenericJackson2JsonRedisSerializer` 전략과 일치시킨다.
+
+## 문제 상세
+
+### RedisCloudUsageCacheAdapter — 수동 직렬화 불일치
+
+```java
+// 현재: Spring Boot 기본 ObjectMapper 주입 (Redis 설정 없음)
+private final RedisTemplate<String, String> redisTemplate;
+private final ObjectMapper objectMapper;  // ← Spring MVC의 기본 ObjectMapper
+
+// 저장 시 수동 직렬화
+String json = objectMapper.writeValueAsString(usage);
+redisTemplate.opsForValue().set(key, json, ttlSeconds, TimeUnit.SECONDS);
+
+// 읽기 시 수동 역직렬화
+String json = redisTemplate.opsForValue().get(key);
+CloudUsage usage = objectMapper.readValue(json, CloudUsage.class);
+```
+
+**문제점:**
+- `RedisTemplate<String, String>`은 값을 plain String으로 저장 → `@class` 타입 정보 없음
+- 주입되는 `ObjectMapper`가 Redis용 설정(`JavaTimeModule` + `activateDefaultTyping`)을 갖고 있지 않으면 `LocalDate` 직렬화 오류 발생
+- `CloudUsage`가 패키지 이동되어도 타입 정보가 없으므로 `readValue(json, CloudUsage.class)` 방식은 타입 명시로 안전하지만, 다른 어댑터와 전략이 달라 혼란 야기
+
+### RedisRateLimitStorageAdapter — Map fallback 패턴
+
+```java
+// 현재: GenericJackson2JsonRedisSerializer가 저장 시 @class 포함 JSON 생성
+redisTemplate.opsForValue().set(KEY_PREFIX + clientId, submissionState, RECORD_TTL);
+
+// 읽기 시 타입 정보가 있으면 SpamSubmissionRecord로 역직렬화 되어야 하지만
+// Redis 저장값이 LinkedHashMap으로 역직렬화되는 경우를 방어하는 코드
+private SpamSubmissionRecord fromRedisValue(Object raw) {
+    if (raw instanceof SpamSubmissionRecord r) { return r; }
+    if (raw instanceof Map<?, ?> map) { ... }  // ← 이 경로가 실행된다는 것 자체가 문제
+}
+```
+
+**문제점:**
+- `GenericJackson2JsonRedisSerializer`가 제대로 작동하면 `raw instanceof SpamSubmissionRecord`가 항상 참이어야 함
+- `Map<?, ?>` fallback이 실행된다는 것은 역직렬화 과정에서 타입 정보가 무시되고 있다는 신호
+- P01 완료 후에도 이 문제가 지속된다면 `SpamSubmissionRecord` 클래스 자체의 직렬화 설정 이슈
+
+## 구현 상세
+
+### 1. RedisCloudUsageCacheAdapter 리팩토링
+
+**변경 파일:** `infrastructure/cache/RedisCloudUsageCacheAdapter.java`
+
+```java
+// Before
+private final RedisTemplate<String, String> redisTemplate;
+private final ObjectMapper objectMapper;
+
+// After
+private final RedisTemplate<String, Object> redisTemplate;  // String → Object 타입 변경
+// ObjectMapper 필드 제거 (RedisTemplate의 serializer가 처리)
+```
+
+수동 직렬화/역직렬화 코드 제거:
+```java
+// Before
+String json = objectMapper.writeValueAsString(usage);
+redisTemplate.opsForValue().set(key, json, ttlSeconds, TimeUnit.SECONDS);
+
+// After
+redisTemplate.opsForValue().set(key, usage, ttlSeconds, TimeUnit.SECONDS);
+```
+
+역직렬화:
+```java
+// Before
+String json = redisTemplate.opsForValue().get(key);
+CloudUsage usage = objectMapper.readValue(json, CloudUsage.class);
+
+// After
+Object raw = redisTemplate.opsForValue().get(key);
+if (raw instanceof CloudUsage usage) {
+    return usage;
+}
+// GenericJackson2JsonRedisSerializer는 @class 기반으로 CloudUsage를 복원하므로
+// Map fallback 없이 타입 캐스팅만으로 충분
+log.warn("Unexpected type for cloud usage cache: key={}, type={}", key,
+    raw != null ? raw.getClass().getName() : "null");
+return null;
+```
+
+**주의:** `RedisTemplate<String, Object>` 빈은 `RedisConfig`에서 이미 `GenericJackson2JsonRedisSerializer`로 설정되어 있으므로 추가 설정 불필요.
+
+### 2. RedisRateLimitStorageAdapter Map fallback 제거
+
+**변경 파일:** `infrastructure/persistence/redis/adapter/RedisRateLimitStorageAdapter.java`
+
+P01 완료 후 Redis 플러시 → 재저장된 데이터는 모두 `@class` 포함 형식으로 저장됨.
+`Map<?, ?>` fallback이 더 이상 필요 없어지므로 제거.
+
+```java
+// After
+private SpamSubmissionRecord fromRedisValue(Object raw) {
+    if (raw == null) return null;
+    if (raw instanceof SpamSubmissionRecord r) return r;
+    // Map fallback 제거
+    log.warn("Unexpected Redis value type for spam record: {}", raw.getClass().getName());
+    return null;
+}
+```
+
+**만약 P01 완료 후에도 Map fallback이 실행된다면:**  
+`SpamSubmissionRecord` 클래스에 문제가 있는 것이므로 아래를 확인:
+- Lombok `@Data` 또는 `@Getter/@Setter` 적용 여부 (역직렬화 시 기본 생성자 필요)
+- `@JsonCreator` 또는 기본 생성자 존재 여부
+
+### 3. 기존 캐시 데이터 마이그레이션
+
+P02 완료 후 Redis 플러시 실행:
+```
+POST /api/admin/cache/flush
+```
+`cloud_usage:daily:*` 키 패턴 데이터도 포함 (90일 TTL이므로 자동 만료 대기 불가).
+
+## 완료 기준 (체크리스트)
+
+- [x] `RedisCloudUsageCacheAdapter`: `RedisTemplate<String, String>` → `RedisTemplate<String, Object>` 교체
+- [x] `RedisCloudUsageCacheAdapter`: `objectMapper` 필드 제거, 수동 직렬화/역직렬화 코드 제거
+- [x] `RedisCloudUsageCacheAdapter`: `getDailyUsage` 등 `objectMapper.readValue()` 호출 제거
+- [x] `RedisRateLimitStorageAdapter`: `Map<?, ?>` fallback 코드 제거
+- [x] `CloudUsage`: Jackson/Redis 역직렬화용 `@NoArgsConstructor` / `@AllArgsConstructor` 추가 (기존 `@Builder` 유지)
+- [x] `SpamSubmissionRecord`: 기본 생성자 (`@NoArgsConstructor`) 기존 유지 확인
+- [x] Docker `backend`에서 `mvn test` 성공; `RedisAdapterSerializationIntegrationTest`로 어댑터 라운드트립 검증
+- [ ] 로컬에서 스팸·CloudUsage 수동 스모크 (선택)
+- [ ] P02 반영 후 Redis 전체 플러시 (`POST /api/admin/cache/flush`) 권고

--- a/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P03-cache-eviction-refinement.md
+++ b/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P03-cache-eviction-refinement.md
@@ -1,0 +1,137 @@
+# P03: 캐시 무효화 전략 세분화
+
+## 목표
+
+`allEntries=true`로 인한 전체 캐시 플러시를 제거하고,
+변경된 데이터의 키만 정확하게 무효화하는 세분화된 전략을 도입한다.
+아울러 캐시 키 문자열을 상수로 통합 관리한다.
+
+## 문제 상세
+
+### 현재 전략의 문제
+
+```java
+// ManageExperienceService, ManageEducationService, ManageProjectService 등 공통 패턴
+@CacheEvict(value = "portfolio", allEntries = true)
+public void createExperience(CreateExperienceCommand command) { ... }
+```
+
+`allEntries = true`는 `portfolio` 캐시의 **모든 키**를 제거한다:
+- experiences:all
+- educations:all
+- certifications:all
+- projects:all
+
+즉, Experience 하나를 추가해도 Education 캐시까지 지워지는 구조.
+트래픽이 많은 시간대에 캐시 콜드 스타트가 집중될 수 있다.
+
+### 캐시 키 문자열 분산
+
+현재 캐시 키 문자열(`"experiences:all"`, `"portfolio"` 등)이 서비스 파일마다 분산되어 있어
+오타나 불일치가 발생해도 컴파일 시 감지 불가.
+
+## 구현 상세
+
+### 1. CacheKeys 상수 클래스 생성
+
+**새 파일:**  
+`backend/src/main/java/com/aiportfolio/backend/infrastructure/config/CacheKeys.java`
+
+```java
+public final class CacheKeys {
+    private CacheKeys() {}
+
+    // 캐시 이름 (value= 파라미터)
+    public static final String PORTFOLIO = "portfolio";
+    public static final String GITHUB = "github";
+
+    // 포트폴리오 캐시 키
+    public static final String EXPERIENCES_ALL = "experiences:all";
+    public static final String EDUCATIONS_ALL = "educations:all";
+    public static final String CERTIFICATIONS_ALL = "certifications:all";
+    public static final String PROJECTS_ALL = "projects:all";
+
+    // GitHub 캐시 키
+    public static final String GITHUB_PROJECTS = "projects";
+    public static final String GITHUB_PROJECT_PREFIX = "project:";
+
+    // 기타
+    public static final String FRONTEND_CACHE_VERSION = "frontend:cache:version";
+}
+```
+
+### 2. PortfolioService @Cacheable 키 교체
+
+**변경 파일:** `application/portfolio/PortfolioService.java`
+
+```java
+// Before
+@Cacheable(value = "portfolio", key = "'experiences:all'")
+
+// After
+@Cacheable(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EXPERIENCES_ALL + "'")
+```
+
+4개 메서드 모두 적용 (experiences, educations, certifications, projects).
+
+### 3. 각 Manage 서비스 @CacheEvict 세분화
+
+**변경 파일 목록:**
+- `ManageExperienceService.java`
+- `ManageEducationService.java`
+- `ManageCertificationService.java`
+- `ManageProjectService.java`
+- `ManageArticleService.java`
+- `ManageTechStackMetadataService.java`
+
+**패턴 변경:**
+```java
+// Before (ManageExperienceService)
+@CacheEvict(value = "portfolio", allEntries = true)
+public void createExperience(...) { ... }
+
+// After — 해당 데이터 타입 키만 무효화
+@CacheEvict(value = CacheKeys.PORTFOLIO, key = "'" + CacheKeys.EXPERIENCES_ALL + "'")
+public void createExperience(...) { ... }
+```
+
+**매핑 기준:**
+| 서비스 | 무효화 대상 키 |
+|---|---|
+| ManageExperienceService | `experiences:all` |
+| ManageEducationService | `educations:all` |
+| ManageCertificationService | `certifications:all` |
+| ManageProjectService | `projects:all` |
+| ManageArticleService | `projects:all` (Article은 Project 하위) |
+| ManageTechStackMetadataService | `projects:all` (기술 스택은 프로젝트 캐시에 포함) |
+
+**주의:** `ManageArticleService`와 `ManageTechStackMetadataService`가 `portfolio` 캐시의 어떤 키에 영향을 주는지 실제 데이터 구조 확인 후 결정. 불확실하면 해당 서비스는 `allEntries=true` 유지.
+
+### 4. refreshCache() 메서드 정리
+
+`ProjectApplicationService.refreshCache()`가 `{"portfolio", "github"}` 전체를 evict하는 것은 
+관리자 수동 실행 용도이므로 유지. 단, 키 문자열은 상수로 교체:
+
+```java
+@Caching(evict = {
+    @CacheEvict(value = CacheKeys.PORTFOLIO, allEntries = true),
+    @CacheEvict(value = CacheKeys.GITHUB, allEntries = true)
+})
+public void refreshCache() { ... }
+```
+
+## 완료 기준 (체크리스트)
+
+- [x] `CacheKeys.java` 생성, 모든 캐시 이름/키 상수 정의
+- [x] `PortfolioService`: `@Cacheable` 4개·`refreshProjectsCache`·`refreshCache`에 상수/`@Caching` 적용
+- [x] `ProjectApplicationService`: 동일 (`ManageProjectCacheUseCase` 구현체)
+- [x] `ManageExperienceService`: `experiences:all` 키 단위 evict
+- [x] `ManageEducationService`: `educations:all` 키 단위 evict
+- [x] `ManageCertificationService`: `certifications:all` 키 단위 evict
+- [x] `ManageProjectService`: `projects:all` 키 단위 evict
+- [x] `ManageArticleService`: `projects:all` 키 단위 evict (프로젝트·아티클 연동)
+- [x] `ManageTechStackMetadataService` / `UpdateTechStackSortOrderService`: `projects:all` 키 단위 evict
+- [x] `GitHubIntegrationService`: `github` 캐시 이름·키 프리픽스 상수화
+- [x] `CacheConfig`: 캐시 이름 등록에 `CacheKeys` 사용
+- [x] Docker `backend`에서 `mvn test` 성공
+- [ ] 로컬에서 관리자 변경 시 해당 키만 무효화되는지 스모크 (선택)

--- a/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P04-redis-cloud-compatibility.md
+++ b/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P04-redis-cloud-compatibility.md
@@ -1,0 +1,121 @@
+# P04: Redis Cloud 7.4 호환성 검증 및 회귀 방지
+
+## 목표
+
+Redis Cloud 7.4 환경에서의 연결 설정을 검토하고,
+P01~P03에서 수정한 직렬화/캐시 전략이 실제 Redis 서버에서 정상 작동함을 검증한다.
+이후 동일 문제가 재발하지 않도록 회귀 방지 테스트를 구축한다.
+
+## 문제 상세
+
+### Redis Cloud 7.4 환경 특이사항
+
+**KEYS 명령어 이슈:**
+`RedisCacheManagementAdapter`에 `SCAN → KEYS fallback`이 존재한다.
+Redis Cloud에서는 `KEYS *`가 성능 보호 정책으로 차단될 수 있으며,
+이 경우 `getStatistics()`, `getKeysByPattern()` 메서드가 빈 결과를 반환하거나 예외를 발생시킨다.
+
+**연결 풀 및 timeout 불일치:**
+| 환경 | timeout | max-active | SSL |
+|---|---|---|---|
+| local | 2000ms | 8 | false |
+| staging | 10000ms | (기본값) | 미확인 |
+| production | 2000ms | (기본값) | 미확인 |
+
+Redis Cloud는 TLS/SSL을 요구하는 경우가 있으며, staging timeout이 유독 길게 설정되어 있는 이유 확인 필요.
+
+### 현재 회귀 방지 수단 없음
+
+직렬화 문제가 발생해도 캐시는 조용히 실패(silent failure)하므로
+배포 후 한참 지나서야 문제를 인지하게 되는 구조.
+
+## 구현 상세
+
+### 1. RedisCacheManagementAdapter KEYS fallback 제거
+
+**변경 파일:** `infrastructure/persistence/redis/adapter/RedisCacheManagementAdapter.java`
+
+Redis Cloud 7.4는 SCAN을 완전 지원한다. KEYS fallback을 제거하고 SCAN만 사용:
+
+```java
+// Before
+try {
+    // SCAN 방식
+    cursor = redisTemplate.scan(ScanOptions.scanOptions().match(pattern).count(100).build());
+    ...
+} catch (Exception e) {
+    // KEYS fallback
+    Set<String> keys = redisTemplate.keys(pattern);  // ← 제거 대상
+    ...
+}
+
+// After — SCAN만 사용, KEYS fallback 없음
+// SCAN 실패 시 빈 Set 반환 또는 로그만 기록
+```
+
+### 2. application-staging.yml SSL 설정 확인 및 통일
+
+**변경 파일:** `application-staging.yml`, `application-production.yml`
+
+Redis Cloud 7.4 연결 시 SSL 필수 여부 확인:
+```yaml
+spring:
+  data:
+    redis:
+      ssl:
+        enabled: true  # Redis Cloud 요구 사항이면 staging/production 모두 활성화
+      timeout: 3000ms  # staging의 10000ms → 실제 필요치 기반으로 조정
+```
+
+staging timeout 10000ms 설정 이유 확인 후 불필요하다면 production과 동일하게 조정.
+
+### 3. 직렬화 단위 테스트 추가
+
+**새 파일:**  
+`backend/src/test/java/com/aiportfolio/backend/infrastructure/config/RedisSerializationTest.java`
+
+```java
+@SpringBootTest
+@ActiveProfiles("local")
+class RedisSerializationTest {
+
+    @Autowired
+    @Qualifier("redisObjectMapper")
+    private ObjectMapper redisObjectMapper;
+
+    @Test
+    void redisObjectMapper_should_serialize_and_deserialize_CloudUsage_with_LocalDate() {
+        CloudUsage usage = new CloudUsage(...);
+        String json = redisObjectMapper.writeValueAsString(usage);
+        CloudUsage restored = redisObjectMapper.readValue(json, CloudUsage.class);
+        assertThat(restored.getDate()).isEqualTo(usage.getDate());
+    }
+
+    @Test
+    void redisObjectMapper_should_serialize_SpamSubmissionRecord() { ... }
+
+    @Test
+    void genericJackson2JsonSerializer_should_include_class_property() {
+        // @class 필드가 포함된 JSON 생성 확인
+    }
+}
+```
+
+**목적:** P01에서 통합한 ObjectMapper 설정이 요구 사항을 충족하는지 빠르게 검증.
+Redis 서버 연결 없이 직렬화 로직만 단독 테스트 가능.
+
+### 4. Admin 캐시 헬스체크 엔드포인트 문서화
+
+기존 `GET /api/admin/cache/stats` 응답에 직렬화 버전 또는 설정 식별자를 추가하면
+배포 후 직렬화 설정이 올바르게 적용됐는지 확인하는 데 활용 가능.
+(선택 구현 — 우선순위 낮음)
+
+## 완료 기준 (체크리스트)
+
+- [x] `RedisCacheManagementAdapter`: `KEYS` fallback 제거, SCAN 실패 시 빈 `Set` 반환 및 로그
+- [x] `application-staging.yml`: Redis `timeout` 10000ms → **3000ms** (SCAN 전용·로컬/프덕과 정렬), SSL은 기존 `${REDIS_SSL}` 유지
+- [x] SSL: staging/production 모두 `spring.data.redis.ssl.enabled: ${REDIS_SSL}` — Redis Cloud는 배포 환경에서 `REDIS_SSL` 설정으로 반영
+- [x] `RedisSerializationTest.java`: CloudUsage+LocalDate, SpamSubmissionRecord, `@class` 포함 JSON (3케이스)
+- [x] Docker `backend`에서 `mvn test`·`-Dtest=RedisSerializationTest` 통과
+- [ ] staging 배포 후 `GET /api/admin/cache/stats` (수동)
+- [ ] staging 배포 후 포트폴리오 API 캐시 동작 (수동)

--- a/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P05-skill-review-and-remediation.md
+++ b/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/P05-skill-review-and-remediation.md
@@ -1,0 +1,95 @@
+# P05: 스킬 기반 검토 및 반영
+
+## 전제 조건
+
+**P01~P04 구현이 끝난 뒤** 착수한다. 코드 변경은 “검토에서 발견된 항목”에 한정한다.
+
+## 목표
+
+프로젝트 로컬 `.cursor/skills/`에 복제한 basis 검토 스킬을 **E02 변경 범위**에 적용하고, 결과를 문서로 남긴다.  
+**치명도가 낮은 개선**은 이 Phase에서 코드·에픽 문서에 반영하고, **범위 밖·대형 리팩터**는 백로그나 후속 에픽으로 넘긴다.
+
+## 적용 스킬 (역할)
+
+| 스킬 `name` | 역할 |
+|-------------|------|
+| `epic-architecture-review` | 에픽 단위: 레이어·의존 방향·Bounded Context·문서화된 선택 근거 |
+| `pt-01-domain-modeling` | 도메인 모델·Aggregate/VO 경계 (캐시/직렬화와의 관계만 해당 시) |
+| `pt-02-implementation-patterns` | Redis 어댑터 등 **Adapter** 형태 준수 여부 |
+| `cc-02-method-level` | Application/Domain **메서드·호출 구조** (캐시 어노테이션 포함 서비스 샘플) |
+| `cc-05-code-hygiene` | 주석 위치·미사용 코드·import |
+| `file-basis-review` | **파일 단위** CN-01·CC-01~02·04·05 종합 패스 (대표 파일) |
+
+스킬 정의 본문: 각 폴더의 `SKILL.md`.
+
+## 구현 상세
+
+### 1. 검토 범위 (파일·디렉터리 우선순위)
+
+**필수 샘플 (file-basis-review 최소 3파일):**
+
+- `infrastructure/config/RedisObjectMapperConfig.java`
+- `infrastructure/config/CacheKeys.java`
+- `infrastructure/cache/RedisCloudUsageCacheAdapter.java` 또는 `RedisRateLimitStorageAdapter.java`
+
+**선택 샘플:**
+
+- `infrastructure/persistence/redis/adapter/RedisCacheManagementAdapter.java`
+- `application/admin/service/ManageExperienceService.java` (또는 동일 패턴 Manage* 1개)
+- `application/portfolio/PortfolioService.java` (`@Cacheable`/`@CacheEvict`)
+
+### 2. 스킬별 산출물 (이 문서에 섹션으로 기록)
+
+| 스킬 | 기록할 내용 |
+|------|-------------|
+| epic-architecture-review | 통과/플래그, 에픽 README와 코드 불일치 시 **한 줄** 정리 |
+| pt-01 | 도메인 모델 변경(`CloudUsage` 등)에 대한 판단 요약 |
+| pt-02 | 포트–어댑터 분리·외부 타입 누수 여부 |
+| cc-02 | 캐시 무효화가 Application 레이어 관심사로만 있는지 |
+| cc-05 | 위반 0건 또는 수정 내역 |
+| file-basis-review | 샘플 파일별 Pass / 수정 완료 |
+
+### 3. 반영 규칙
+
+- **문서만:** 에픽 `Readme.md`의 `배경/맥락`이 현재 구조와 어긋나면 짧게 수정한다.
+- **코드:** CC-05-03/04, 명백한 네이밍·import 정도만 — 동작 변경이 큰 리팩터는 하지 않는다.
+- 검증: 수정이 있으면 Docker `backend`에서 `mvn test` 실행 (`AGENTS.md`).
+
+## 완료 기준 (체크리스트)
+
+- [ ] `epic-architecture-review` 체크 완료, 결과 이 문서에 기록
+- [ ] `pt-01-domain-modeling` 검토 완료, 결과 이 문서에 기록
+- [ ] `pt-02-implementation-patterns` 검토 완료, 결과 이 문서에 기록
+- [ ] `cc-02-method-level` 검토 완료 (대표 Application 서비스 1개 이상), 결과 기록
+- [ ] `cc-05-code-hygiene` 검토 완료, 발견 시 수정 또는 “의도적 유지” 사유
+- [ ] `file-basis-review` 대표 파일 3개 이상 패스 또는 수정 완료
+- [ ] 에픽 README와 코드 불일치 시 README 보강 또는 “현재 기준” 한 줄 명시
+- [ ] 코드 변경이 있었다면 Docker `backend`에서 `mvn test` 성공
+
+## 검토 결과 (작성용)
+
+### epic-architecture-review
+
+- (작성)
+
+### pt-01-domain-modeling
+
+- (작성)
+
+### pt-02-implementation-patterns
+
+- (작성)
+
+### cc-02-method-level
+
+- (작성)
+
+### cc-05-code-hygiene
+
+- (작성)
+
+### file-basis-review (파일별)
+
+| 파일 | 결과 |
+|------|------|
+| | |

--- a/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/Readme.md
+++ b/docs/epic/E02.2026-04-03_redis-cache-serialization-refactor/Readme.md
@@ -1,0 +1,116 @@
+# Epic E02: redis-cache-serialization-refactor
+
+## 목표
+
+Redis Cloud 7.4 환경에서 반복적으로 발생하는 직렬화/역직렬화 오류를 근본적으로 해결하고,
+캐시 관련 Spring Boot 코드 전반을 일관된 전략으로 리팩토링한다.
+
+구체적으로:
+- ObjectMapper 설정을 단일 빈으로 중앙화하여 설정 불일치 제거
+- 어댑터별로 다른 직렬화 방식을 `GenericJackson2JsonRedisSerializer` 기반으로 통일
+- `allEntries=true` 전략 제거, 키 단위 세분화된 캐시 무효화 도입
+- Redis Cloud 7.4 호환성 검증 및 회귀 방지 테스트 구축
+
+## 배경 / 맥락
+
+### 반복 발생 중인 직렬화 문제의 원인 구조
+
+현재 캐시 시스템은 아래 세 가지 불일치가 겹쳐 직렬화 오류가 반복 발생하고 있다.
+
+**1. ObjectMapper 인스턴스 분산**
+- `RedisConfig`와 `CacheConfig`가 각각 `new GenericJackson2JsonRedisSerializer()`를 생성
+- 두 직렬화기의 내부 ObjectMapper는 서로 다른 인스턴스 → 설정이 조금이라도 달라지면 저장/읽기 형식 불일치 발생
+- 관련 커밋: `5738535 fix(api/cache): use default Redis JSON typing`, `573df97 fix: Education 및 Experience API 직렬화 문제 해결`
+
+**2. 어댑터별 직렬화 전략 혼재**
+- `RedisRateLimitStorageAdapter`: `RedisTemplate<String, Object>` 사용, `GenericJackson2JsonRedisSerializer`로 저장하지만 읽기 시 `Map<?, ?>` fallback 처리 — 타입 정보가 있어야 할 자리에 없을 때 발생하는 방어 코드
+- `RedisCloudUsageCacheAdapter`: `RedisTemplate<String, String>` + 수동 `objectMapper.writeValueAsString()` 사용 — Spring Boot 기본 ObjectMapper를 주입받아 사용하므로 Redis 전용 직렬화 설정이 적용되지 않음
+
+**3. `@class` 타입 정보의 취약성**
+- `GenericJackson2JsonRedisSerializer`는 저장 시 `{"@class":"com.aiportfolio.backend...ClassName", ...}` 형태로 저장
+- 클래스 패키지 이동, 이름 변경 시 기존 캐시 데이터 역직렬화 불가
+- CacheConfig 주석에도 WRAPPER_ARRAY vs PROPERTY 충돌이 문서화되어 있음
+
+### Redis Cloud 7.4 환경 특이사항
+
+- `KEYS *` 명령어는 Redis Cloud에서 실행 시 서버 부하 이슈로 차단될 수 있음
+- `RedisCacheManagementAdapter`의 `SCAN → KEYS fallback` 패턴이 Cloud 환경에서 예상과 다르게 동작할 가능성
+- 연결 풀 설정과 timeout이 환경별로 다르게 설정되어 있어 일관성 검토 필요
+
+## 특이점
+
+- 백엔드는 헥사고날 아키텍처를 지향하므로 직렬화 설정은 `infrastructure/config` 레이어에 위치
+- 도메인 모델(`CloudUsage`, `SpamSubmissionRecord`)에 직렬화 어노테이션 추가 시 도메인 오염 최소화 주의
+- 각 Phase는 단독 배포 가능한 단위로 구성하되, P01 완료 전 P02 착수 불가 (의존 관계 있음)
+- P05는 P01~P04 구현 후 **스킬 기반 검토·문서/경미 수정** 전용이며, 기능 추가 범위에 넣지 않는다
+- Redis에 저장된 기존 캐시 데이터는 P01/P02 완료 후 플러시 필요 (직렬화 형식 변경으로 인한 깨진 캐시 제거)
+
+## 구현 시 준수 원칙 (코드·메서드·주석)
+
+에픽·Phase 문서 구조는 `epic-lifecycle`(DC-05)을 따른다. 아래는 **이 에픽에서 코드 작성 시** 동일하게 적용하는 basis 요약이다. (인프라·설정 코드가 많은 경우 **CC-01**은 순수 로직·계산에 집중해 적용하고, **CC-02**는 Application/Domain 경계가 바뀔 때 위주로 적용한다.)
+
+### CC-05 코드 위생 (주석·미사용 코드)
+
+| ID | 요지 |
+|----|------|
+| CC-05-01 | 코드만으로 알 수 없는 배경·제약·외부 약속은 **장문 주석이 아니라 문서**(이 에픽·Phase, `docs/` 등)에 두고, 소스에는 **경로·이슈·ADR 식별자** 수준만 참조한다. |
+| CC-05-02 | **설명 주석은 파일(모듈) 상단만** — 역할 한 줄, 공식 문서 링크, 반드시 필요한 주의 한 줄. 구현 라인 옆의 why·단계 나열·보일러플레이트 주석은 쓰지 않는다. (스택이 요구하는 공개 API 문서화·TODO는 해당 규칙 예외.) |
+| CC-05-03 | dead store, unused private, unused parameter는 제거한다. (프레임워크가 시그니처를 강제하는 파라미터는 예외.) |
+| CC-05-04 | **미사용 import 없음.** |
+
+### CC-01 로직 레벨 (순수 로직·계산·변환)
+
+**우선순위:** 가독성 → 예측 가능성(동일 패턴 반복) → 단순성.
+
+| 티어 | ID | 요지 |
+|------|-----|------|
+| Core | CC-01-01 | 로직은 **위→아래 한 방향** 선형 흐름. |
+| Core | CC-01-02 | **Early return** — 예외 조건은 상단에서 처리 후 본문은 정상 흐름만. (조건 하나·본문 1~2줄이면 단순 if-else 허용.) |
+| Core | CC-01-03 | 조건문 **중첩 최대 1단계**. 더 필요하면 조건 분리·함수 추출. |
+| Core | CC-01-04 | 같은 의미가 단계적으로 정제될 때만 **동일 변수 재할당**; 이름이 더는 맞지 않으면 별도 변수(CC-01-06). |
+| Guide | CC-01-05 | 변수명은 **그 시점 상태**를 반영; `data`, `tmp`, `result2` 등 금지 이름 피함. |
+| Guide | CC-01-06 | **한 변수에 서로 다른 의미** 재할당 금지. |
+| Guide | CC-01-07 | 컬렉션 순회는 **명령형 루프 기본**; 단계마다 단일 연산·부수효과 없는 **순수 체이닝**은 허용. 중간이 안 보이면 명령형으로. |
+| Core | CC-01-08 | 순수 로직은 **외부 의존을 인자로**; 동일 입력→동일 결과. |
+| Guide | CC-01-09 | 함수 복잡도: **책임 1**, **상태 변화(선언·재할당) 5회 이내**, **분기 3개 이내**, **한 조건식의 AND/OR 2개 이내**. 초과 시 분리. |
+| Guide | CC-01-10 | **final** 우선(CC-01-04 단계적 변환·루프 카운터 등 예외). |
+
+### CC-02 메서드·레이어 (호출 구조)
+
+**우선순위:** 레이어 경계 유지 → 가독성 → 단순성.
+
+| 티어 | ID | 요지 |
+|------|-----|------|
+| Core | CC-02-01 | **Application**은 흐름만; **계산은 Domain**으로 위임. |
+| Core | CC-02-02 | **비즈니스 계산**은 Application에 직접 쓰지 않는다. (DTO 변환·null 체크 등 **데이터 정리**만 Application에서 허용.) |
+| Core | CC-02-03 | 호출은 **Application → Domain**, **Application → Infrastructure** 방향만. Domain이 인프라를 부르지 않는다; 필요한 값은 Application이 조회해 인자로 넘긴다. |
+| Core | CC-02-04 | **Application 메서드 하나 = 유스케이스 하나.** |
+| Core | CC-02-05 | **부수효과(DB·API·메시지 등)** 는 **Application에서만** 발생. |
+| Guide | CC-02-06 | Domain 호출은 **의미 단위**로 묶는다 — 잘게 쪼개 조합만 Application에 남기지 않는다. |
+
+### 스택·검증 (프로젝트 스킬)
+
+- **Spring·레이어:** Redis/캐시 `@Configuration`·어댑터는 `infrastructure`·`config`; 비즈니스 규칙은 도메인·애플리케이션. (`spring-boot-stack`)
+- **Java:** 네이밍, record/stream/예외, 불변성 (`java-stack`).
+- **도메인·애플리케이션 변경:** `layered-tdd-workflow`(TC-01) 범위면 해당 레이어 테스트·커밋 순서.
+- **완료 주장 전:** `evidence-before-completion`; Maven은 `AGENTS.md`대로 Docker `backend` 컨테이너에서 실행.
+
+## Phase 목록
+
+- [P01: ObjectMapper 중앙화 및 직렬화 설정 통합](./P01-objectmapper-centralization.md)
+- [P02: 어댑터 직렬화 일관성 확보](./P02-adapter-serialization-consistency.md)
+- [P03: 캐시 무효화 전략 세분화](./P03-cache-eviction-refinement.md)
+- [P04: Redis Cloud 호환성 검증 및 회귀 방지](./P04-redis-cloud-compatibility.md)
+- [P05: 스킬 기반 검토 및 반영](./P05-skill-review-and-remediation.md)
+
+## 상태
+
+- [x] P01 완료 — `redisObjectMapper` 중앙화, 통합 테스트 (`RedisSerializationConfigIntegrationTest` 등)
+- [x] P02 완료 — 어댑터 직렬화 통일, `RedisAdapterSerializationIntegrationTest`
+- [x] P03 완료 — `CacheKeys`, 키 단위 `@CacheEvict`
+- [x] P04 완료 — `RedisCacheManagementAdapter` KEYS 폴백 제거, `RedisSerializationTest`, staging `timeout` 정리
+- [ ] P05 완료 — `epic-architecture-review`·`pt-01`·`pt-02`·`cc-02`·`cc-05`·`file-basis-review` 적용 및 [P05 문서](./P05-skill-review-and-remediation.md) 기록
+
+**남은 운영·수동 항목 (에픽 외부/배포 후):** Redis 플러시(직렬화 형식 변경 시), staging에서 `GET /api/admin/cache/stats`·포트폴리오 API 스모크 — [P04 체크리스트](./P04-redis-cloud-compatibility.md) 참고.
+
+**아카이브:** `epic-lifecycle`에 따라 P05까지 검토·체크리스트 반영 후 `docs/archive/`로 옮길 때 README에 완료일을 적는다.

--- a/docs/epic/README.md
+++ b/docs/epic/README.md
@@ -8,6 +8,7 @@
 - [code-quality-and-test-foundation/](./code-quality-and-test-foundation/) - 코드 품질 개선 및 테스트 기반 구축 (우선순위: High; Sonar 배치·검증은 [P07](./code-quality-and-test-foundation/P07-sonarqube-quality-execution.md))
 
 ### 계획 중인 에픽 (Backlog)
+- [E02.2026-04-03_redis-cache-serialization-refactor/](./E02.2026-04-03_redis-cache-serialization-refactor/) — Epic E02: Redis 직렬화 근본 해결 및 캐시 전략 리팩토링 (우선순위: High, P01~P05)
 - [detail-page-ux-bugfix/](./detail-page-ux-bugfix/) - 상세 페이지 UX 버그픽스 (우선순위: High, 예상 기간: 1주)
 - [seo-aeo-optimization/](./seo-aeo-optimization/) - SEO/AEO 최적화 (우선순위: High, 예상 기간: 3-4주)
 - [ux-data-loading-optimization/](./ux-data-loading-optimization/) - UX 및 데이터 로딩 최적화 (우선순위: High, 예상 기간: 2-3주)


### PR DESCRIPTION
Redis·Spring Cache에 공유 ObjectMapper와 CacheKeys를 두고, 어댑터 직렬화·관리 어댑터 동작을 정리. Epic E02 문서(P01~P05)와 AGENTS 스킬 라우팅을 반영.

Refs: E02/P05
Made-with: Cursor