### PR TITLE
fix(chatbot): fix input bar visibility and layout

### DIFF
--- a/frontend/src/design-system/styles/globals.css
+++ b/frontend/src/design-system/styles/globals.css
@@ -13,7 +13,7 @@
 
 :root {
   /* Layout - sticky ?ㅻ뜑 ?믪씠 (?댁떆 ?ㅽ겕濡??ㅽ봽???깆뿉 ?ъ슜) */
-  --header-height: 64px;
+  --header-height: 65px; /* 64px container + 1px border-bottom */
 
   /* Breakpoint Tokens - 諛섏쓳???붿옄?몄슜 */
   --breakpoint-mobile: 767px;        /* 紐⑤컮?? 0px ~ 767px */
@@ -418,6 +418,12 @@ body {
 
 :root.dark .hljs-formula {
   background-color: #444;
+}
+
+@media (max-width: 767px) {
+  :root {
+    --header-height: 57px; /* 56px container + 1px border-bottom */
+  }
 }
 
 

--- a/frontend/src/main/app/MainAppRoutes.tsx
+++ b/frontend/src/main/app/MainAppRoutes.tsx
@@ -45,6 +45,8 @@ const MainAppContent: React.FC = () => {
           overflowX: 'hidden',
           overflowY: isChatPage ? 'hidden' : 'auto',
           flex: 1,
+          minHeight: 0,
+          height: isChatPage ? 'calc(100vh - var(--header-height))' : undefined,
           display: 'flex',
           flexDirection: 'column',
         }}

--- a/frontend/src/main/pages/ChatPage/ChatPage.module.css
+++ b/frontend/src/main/pages/ChatPage/ChatPage.module.css
@@ -146,15 +146,14 @@
 .chatPage {
   display: flex;
   flex-direction: column;
-  flex: 1; /* 남은 공간을 모두 차지 */
-  min-height: 0; /* flex 자식이 축소될 수 있도록 */
-  max-width: 72rem; /* max-w-6xl (1152px) - 더 넓은 채팅 영역 */
+  flex: 1;
+  min-height: 0;
+  max-width: 72rem;
   margin: 0 auto;
-  padding: var(--spacing-md, 16px) var(--spacing-md, 16px) var(--spacing-md, 16px) var(--spacing-md, 16px); /* 상단, 좌우, 하단 패딩 */
-  padding-bottom: calc(var(--spacing-md, 16px) + 100px); /* 하단 패딩 + ChatInputBar 높이 여유 공간 (80px → 100px로 증가) */
+  padding: var(--spacing-md, 16px) var(--spacing-md, 16px) 0 var(--spacing-md, 16px);
   position: relative;
   width: 100%;
-  overflow: hidden; /* 채팅 영역이 입력 필드 위에 고정되도록 */
+  overflow: hidden;
 }
 
 /* 초기 상태: 중앙 배치 */
@@ -263,14 +262,9 @@
   justify-content: center;
 }
 
-/* 입력 영역 - 하단 고정 */
+/* 입력 영역 - ChatPage outer flex 하단 */
 .inputContainer {
   flex-shrink: 0;
-  background: var(--color-background, #ffffff);
-  z-index: 10;
-  margin-top: auto;
-  padding-top: var(--spacing-md, 16px);
-  padding-bottom: var(--spacing-md, 16px); /* 하단 패딩 추가 */
 }
 
 /* 다크 모드 지원 */
@@ -331,9 +325,6 @@
     border-color: var(--color-border-default, #374151);
   }
 
-  .inputContainer {
-    background: var(--color-background, #111827);
-  }
 }
 
 /* 반응형 디자인 */

--- a/frontend/src/main/pages/ChatPage/ChatPage.tsx
+++ b/frontend/src/main/pages/ChatPage/ChatPage.tsx
@@ -75,7 +75,7 @@ const ChatPage: React.FC = () => {
       <div
         style={{
           width: '100%',
-          height: '100vh',
+          height: '100%',
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
@@ -108,15 +108,15 @@ const ChatPage: React.FC = () => {
             )}
             <div ref={messagesEndRef} />
           </div>
-
-          <ChatInputSection
-            className={styles.inputContainer}
-            onSendMessage={handleSendMessage}
-            isLoading={isLoading}
-            inputValue={inputValue}
-            onInputChange={setInputValue}
-          />
         </div>
+
+        <ChatInputSection
+          className={styles.inputContainer}
+          onSendMessage={handleSendMessage}
+          isLoading={isLoading}
+          inputValue={inputValue}
+          onInputChange={setInputValue}
+        />
 
         <ContactModal isOpen={isContactModalOpen} onClose={() => setIsContactModalOpen(false)} />
 

--- a/frontend/src/main/shared/ui/chat/ChatInputBar.tsx
+++ b/frontend/src/main/shared/ui/chat/ChatInputBar.tsx
@@ -76,15 +76,15 @@ const ChatInputBar: React.FC<ChatInputBarProps> = ({
   };
 
   return (
-    <div 
-      className="fixed bottom-0 left-0 right-0 border-t z-40 transition-colors"
+    <div
+      className="border-t transition-colors"
       style={{
         backgroundColor: 'var(--color-surface)',
         borderColor: 'var(--color-border)',
         boxShadow: shadows.lg,
       }}
     >
-      <div className="container mx-auto px-4 py-4 max-w-4xl">
+      <div className="mx-auto px-4 py-3" style={{ maxWidth: '1200px' }}>
         <div className="flex items-center gap-3">
           {/* Input Field */}
           <input

--- a/frontend/src/main/shared/ui/page-transition/AnimatedPageTransition.tsx
+++ b/frontend/src/main/shared/ui/page-transition/AnimatedPageTransition.tsx
@@ -29,7 +29,7 @@ export const AnimatedRoutes: React.FC<AnimatedRoutesProps> = ({ children }) => {
 
   useEffect(() => {
     if (isChatPage && containerRef.current) {
-      containerRef.current.style.height = '100vh';
+      containerRef.current.style.height = 'calc(100vh - var(--header-height))';
     }
   }, [isChatPage]);
 
@@ -73,7 +73,7 @@ export const AnimatedRoutes: React.FC<AnimatedRoutesProps> = ({ children }) => {
         overflow: 'hidden',
         width: '100%',
         position: 'relative',
-        height: '100vh',
+        height: 'calc(100vh - var(--header-height))',
       }
     : {
         width: '100%',

--- a/frontend/src/main/widgets/page-layout/ui/PageLayout.module.css
+++ b/frontend/src/main/widgets/page-layout/ui/PageLayout.module.css
@@ -6,6 +6,7 @@
 
 .content {
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
position: fixed 였던 ChatInputBar가 상위의 will-change: transform으로 인해 viewport 대신 컨테이너 기준으로 고정되어 화면 밖으로 밀리던 문제 수정.

AnimatedRoutes 컨테이너가 height: 100vh를 사용해 헤더 높이(65px)만큼 하단이 잘리던 문제를 calc(100vh - var(--header-height))로 수정.

ChatInputSection을 max-width 제약이 있는 .chatPage 내부에서
ChatPageTopBar와 같은 레벨로 이동해 너비 일치.